### PR TITLE
fix: align Codex OAuth image requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ## Unreleased
 
+## 0.3.1
+
+### Improvements
+
+- Align Codex OAuth image requests with Codex built-in image generation by setting `background=auto` and retrying transport or 5xx failures with Codex-style backoff while leaving rate limits non-retried. (#15)
+
 ### Documentation
 
-- Fix README rendering for the Codex Full Access recommendation callout.
+- Fix README rendering for the Codex Full Access recommendation callout. (#15)
 
 ## 0.3.0
 

--- a/skills/image-to-editable-ppt/cli/editppt/runtime/image_gen.py
+++ b/skills/image-to-editable-ppt/cli/editppt/runtime/image_gen.py
@@ -14,7 +14,9 @@ import json
 import mimetypes
 import os
 from pathlib import Path
+import random
 import re
+import socket
 import sys
 import time
 from typing import Any, Dict, Iterable, List, Optional, Tuple
@@ -23,9 +25,12 @@ from urllib import error, request
 DEFAULT_MODEL = "gpt-image-2"
 DEFAULT_SIZE = "auto"
 DEFAULT_QUALITY = "auto"
+DEFAULT_BACKGROUND = "auto"
 DEFAULT_OUTPUT_EXTENSION = "png"
 DEFAULT_OUTPUT_PATH = "output/imagegen/output.png"
 DEFAULT_TIMEOUT = 600
+DEFAULT_CODEX_MAX_RETRIES = 4
+DEFAULT_CODEX_RETRY_BASE_DELAY_SECONDS = 0.2
 GPT_IMAGE_MODEL_PREFIX = "gpt-image-"
 
 ALLOWED_LEGACY_SIZES = {"1024x1024", "1536x1024", "1024x1536", "auto"}
@@ -63,9 +68,10 @@ Input image rules:
   edit passes each --image as an edit target, visual reference, or supporting input.
 
 Parameter surface:
-  Backend requests pass only model, prompt, size, and quality. Edit requests
-  also pass the input images and optional mask. Local controls such as --out,
-  --force, --dry-run, and --timeout are not image API parameters.
+  Public image parameters are model, prompt, size, and quality. Codex OAuth
+  requests also set background=auto to match Codex built-in image generation.
+  Edit requests also pass the input images and optional mask. Local controls
+  such as --out, --force, --dry-run, and --timeout are not image API parameters.
 
 Slide reconstruction patterns:
   Clean base: use edit --image <source.png>; preserve source composition,
@@ -288,12 +294,29 @@ def _codex_image_body(
         "model": model,
         "size": size,
         "quality": quality,
+        "background": DEFAULT_BACKGROUND,
     }
     if image_paths:
         body["images"] = [_codex_image_reference(path) for path in image_paths]
     if mask_path:
         body["mask"] = _codex_image_reference(mask_path)
     return body
+
+
+def _codex_retry_delay(attempt: int) -> float:
+    exp = 2 ** max(attempt - 1, 0)
+    jitter = random.uniform(0.9, 1.1)
+    return DEFAULT_CODEX_RETRY_BASE_DELAY_SECONDS * exp * jitter
+
+
+def _should_retry_codex_http(status: int) -> bool:
+    return 500 <= status <= 599
+
+
+def _format_attempts(attempts: int) -> str:
+    if attempts <= 1:
+        return ""
+    return f" after {attempts} attempts"
 
 
 def _post_codex_image_json(url: str, body: Dict[str, Any], timeout: int) -> Dict[str, Any]:
@@ -310,20 +333,41 @@ def _post_codex_image_json(url: str, body: Dict[str, Any], timeout: int) -> Dict
     }
     if account_id:
         headers["ChatGPT-Account-ID"] = account_id
-    req = request.Request(
-        url,
-        data=json.dumps(body, ensure_ascii=False).encode("utf-8"),
-        method="POST",
-        headers=headers,
-    )
-    try:
-        with request.urlopen(req, timeout=timeout) as resp:
-            text = resp.read(MAX_CODEX_RESPONSE_BYTES).decode("utf-8", errors="replace")
-    except error.HTTPError as exc:
-        detail = exc.read(4096).decode("utf-8", errors="replace")
-        raise RuntimeError(f"Codex Images request failed (HTTP {exc.code}): {detail}") from exc
-    except error.URLError as exc:
-        raise RuntimeError(f"Codex Images request failed: {exc.reason}") from exc
+    data = json.dumps(body, ensure_ascii=False).encode("utf-8")
+
+    for attempt in range(DEFAULT_CODEX_MAX_RETRIES + 1):
+        req = request.Request(
+            url,
+            data=data,
+            method="POST",
+            headers=headers,
+        )
+        try:
+            with request.urlopen(req, timeout=timeout) as resp:
+                text = resp.read(MAX_CODEX_RESPONSE_BYTES).decode("utf-8", errors="replace")
+            break
+        except error.HTTPError as exc:
+            detail = exc.read(4096).decode("utf-8", errors="replace")
+            if attempt < DEFAULT_CODEX_MAX_RETRIES and _should_retry_codex_http(exc.code):
+                time.sleep(_codex_retry_delay(attempt + 1))
+                continue
+            attempts = attempt + 1
+            raise RuntimeError(
+                f"Codex Images request failed{_format_attempts(attempts)} "
+                f"(HTTP {exc.code}): {detail}"
+            ) from exc
+        except (error.URLError, TimeoutError, socket.timeout) as exc:
+            if attempt < DEFAULT_CODEX_MAX_RETRIES:
+                time.sleep(_codex_retry_delay(attempt + 1))
+                continue
+            attempts = attempt + 1
+            reason = getattr(exc, "reason", exc)
+            raise RuntimeError(
+                f"Codex Images request failed{_format_attempts(attempts)}: {reason}"
+            ) from exc
+    else:
+        raise RuntimeError("Codex Images request failed after retry limit.")
+
     try:
         response = json.loads(text)
     except json.JSONDecodeError as exc:
@@ -547,6 +591,7 @@ def _run_codex_image(
                 "mask": str(mask_path) if mask_path else None,
                 "size": args.size,
                 "quality": args.quality,
+                "background": body["background"],
             }
         )
         return True

--- a/tests/test_multi_agent_backend.py
+++ b/tests/test_multi_agent_backend.py
@@ -1,9 +1,12 @@
+import io
 import json
 import os
 import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
+from urllib import error
 import zipfile
 from pathlib import Path
 
@@ -23,6 +26,9 @@ CLI_ENV["PYTHONPATH"] = (
     else str(CLI_DIR) + os.pathsep + CLI_ENV["PYTHONPATH"]
 )
 os.environ["PYTHONPATH"] = CLI_ENV["PYTHONPATH"]
+
+from editppt.runtime import image_gen
+
 
 def write_json(path, data):
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -420,7 +426,8 @@ class MultiAgentBackendTest(unittest.TestCase):
             self.assertEqual([str(source)], payload["input_images"])
             self.assertEqual("auto", payload["size"])
             self.assertEqual("auto", payload["quality"])
-            for removed in ("background", "moderation", "output_format", "output_compression", "n"):
+            self.assertEqual("auto", payload["background"])
+            for removed in ("moderation", "output_format", "output_compression", "n"):
                 self.assertNotIn(removed, payload)
 
     def test_image_generate_dry_run_prefers_codex_images_endpoint_when_auth_exists(self):
@@ -456,8 +463,82 @@ class MultiAgentBackendTest(unittest.TestCase):
             self.assertEqual([], payload["input_images"])
             self.assertEqual("auto", payload["size"])
             self.assertEqual("auto", payload["quality"])
-            for removed in ("background", "moderation", "output_format", "output_compression", "n"):
+            self.assertEqual("auto", payload["background"])
+            for removed in ("moderation", "output_format", "output_compression", "n"):
                 self.assertNotIn(removed, payload)
+
+    def test_codex_oauth_retries_transport_and_5xx_only(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            auth = Path(tmp) / "auth.json"
+            write_json(auth, {"tokens": {"access_token": "test-token"}})
+
+            class FakeResponse:
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, exc_type, exc, tb):
+                    return False
+
+                def read(self, _limit):
+                    return b'{"data":[{"b64_json":"aW1hZ2U="}]}'
+
+            http_500 = error.HTTPError(
+                "https://example.test",
+                500,
+                "server error",
+                hdrs=None,
+                fp=io.BytesIO(b"temporary"),
+            )
+            env = os.environ.copy()
+            env["CODEX_AUTH_FILE"] = str(auth)
+            with mock.patch.dict(os.environ, env, clear=False), mock.patch(
+                "editppt.runtime.image_gen.request.urlopen",
+                side_effect=[http_500, FakeResponse()],
+            ) as urlopen, mock.patch("editppt.runtime.image_gen.time.sleep") as sleep:
+                response = image_gen._post_codex_image_json(
+                    "https://example.test/images/generations",
+                    {"model": "gpt-image-2", "prompt": "test"},
+                    10,
+                )
+
+            self.assertEqual(["aW1hZ2U="], [item["b64_json"] for item in response["data"]])
+            self.assertEqual(2, urlopen.call_count)
+            sleep.assert_called_once()
+
+            with mock.patch.dict(os.environ, env, clear=False), mock.patch(
+                "editppt.runtime.image_gen.request.urlopen",
+                side_effect=[error.URLError("temporary network failure"), FakeResponse()],
+            ) as urlopen, mock.patch("editppt.runtime.image_gen.time.sleep") as sleep:
+                response = image_gen._post_codex_image_json(
+                    "https://example.test/images/generations",
+                    {"model": "gpt-image-2", "prompt": "test"},
+                    10,
+                )
+
+            self.assertEqual(["aW1hZ2U="], [item["b64_json"] for item in response["data"]])
+            self.assertEqual(2, urlopen.call_count)
+            sleep.assert_called_once()
+
+            http_429 = error.HTTPError(
+                "https://example.test",
+                429,
+                "rate limited",
+                hdrs=None,
+                fp=io.BytesIO(b"rate limit"),
+            )
+            with mock.patch.dict(os.environ, env, clear=False), mock.patch(
+                "editppt.runtime.image_gen.request.urlopen",
+                side_effect=http_429,
+            ) as urlopen, mock.patch("editppt.runtime.image_gen.time.sleep") as sleep:
+                with self.assertRaisesRegex(RuntimeError, r"HTTP 429"):
+                    image_gen._post_codex_image_json(
+                        "https://example.test/images/generations",
+                        {"model": "gpt-image-2", "prompt": "test"},
+                        10,
+                    )
+
+            self.assertEqual(1, urlopen.call_count)
+            sleep.assert_not_called()
 
     def test_runtime_config_writes_owner_only_yaml(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

- Add Codex-style retries for Codex OAuth image requests on transport errors and HTTP 5xx responses.
- Set Codex OAuth image request background to auto and expose it in dry-run payloads.
- Cover background and retry behavior with tests.

## User-visible changes

- Codex OAuth image generation and editing is more resilient to transient network/server failures.

## Changelog

- [x] Updated CHANGELOG.md
- [ ] Not needed: internal-only change

## Verification

- python3 -m pytest