### PR TITLE
fix: correct PowerPoint text alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ## Unreleased
 
+### Fixes
+
+- Translate manifest text alignment values to valid DrawingML enums, center preview text within its box, and reject unsupported alignment values during page validation. (#17)
+
 ## 0.3.1
 
 ### Improvements

--- a/skills/image-to-editable-ppt/cli/editppt/runtime/build_pptx_from_manifest.py
+++ b/skills/image-to-editable-ppt/cli/editppt/runtime/build_pptx_from_manifest.py
@@ -19,6 +19,23 @@ ASPECT_TOLERANCE = 0.03
 DEFAULT_TEXT_FIT_SAFETY = 0.9
 DEFAULT_TEXT_LINE_HEIGHT = 1.22
 DEFAULT_MIN_FONT_SIZE = 4.0
+TEXT_ALIGNMENTS = {
+    "left": ("l", "left"),
+    "center": ("ctr", "center"),
+    "right": ("r", "right"),
+    "l": ("l", "left"),
+    "ctr": ("ctr", "center"),
+    "r": ("r", "right"),
+}
+TEXT_VERTICAL_ALIGNMENTS = {
+    "top": ("t", "top"),
+    "middle": ("ctr", "middle"),
+    "center": ("ctr", "middle"),
+    "bottom": ("b", "bottom"),
+    "t": ("t", "top"),
+    "ctr": ("ctr", "middle"),
+    "b": ("b", "bottom"),
+}
 
 
 def emu(value):
@@ -51,6 +68,20 @@ def image_ext(path):
 
 def xml_text(value):
     return html.escape(str(value), quote=True)
+
+
+def text_alignment(value="left"):
+    key = str(value or "left").strip().lower()
+    if key not in TEXT_ALIGNMENTS:
+        raise ValueError(f"Unsupported text align value: {value}")
+    return TEXT_ALIGNMENTS[key]
+
+
+def text_vertical_alignment(value="top"):
+    key = str(value or "top").strip().lower()
+    if key not in TEXT_VERTICAL_ALIGNMENTS:
+        raise ValueError(f"Unsupported text valign value: {value}")
+    return TEXT_VERTICAL_ALIGNMENTS[key]
 
 
 def source_size_px(manifest):
@@ -318,8 +349,8 @@ def text_box_xml(idx, item):
     rotation_attr = f' rot="{int(float(rotation) * 60000)}"' if rotation not in (None, "") else ""
     font_size = int(float(item.get("font_size", 18)) * 100)
     font = xml_text(item.get("font", "PingFang SC"))
-    align = item.get("align", "left")
-    anchor = item.get("valign", "top")
+    align = text_alignment(item.get("align", "left"))[0]
+    anchor = text_vertical_alignment(item.get("valign", "top"))[0]
     wrap = item.get("wrap", "none")
     autofit = item.get("autofit", "none")
     autofit_xml = "<a:spAutoFit/>" if autofit == "shape" else "<a:noAutofit/>"
@@ -823,12 +854,34 @@ def render_preview(manifest, manifest_path, out_path):
         else:
             preview_text = item.get("text", "")
         fill = preview_color(item.get("color", "#111111"))
-        align = item.get("align", "left") if item.get("align", "left") in ("left", "center", "right") else "left"
-        x = int(item.get("left", 0) * scale)
-        y = int(item.get("top", 0) * scale)
+        align = text_alignment(item.get("align", "left"))[1]
+        valign = text_vertical_alignment(item.get("valign", "top"))[1]
+        box_x = int(item.get("left", 0) * scale)
+        box_y = int(item.get("top", 0) * scale)
+        box_width = max(1, int(item.get("width", 1) * scale))
+        box_height = max(1, int(item.get("height", 0.4) * scale))
         rotation = float(item.get("rotation", 0) or 0)
-        if item.get("runs") and not rotation:
-            cursor_x = x
+
+        def aligned_origin(bounds, origin_x, origin_y):
+            text_width = bounds[2] - bounds[0]
+            text_height = bounds[3] - bounds[1]
+            if align == "center":
+                text_x = origin_x + (box_width - text_width) // 2 - bounds[0]
+            elif align == "right":
+                text_x = origin_x + box_width - text_width - bounds[0]
+            else:
+                text_x = origin_x
+            if valign == "middle":
+                text_y = origin_y + (box_height - text_height) // 2 - bounds[1]
+            elif valign == "bottom":
+                text_y = origin_y + box_height - text_height - bounds[1]
+            else:
+                text_y = origin_y
+            return text_x, text_y
+
+        run_specs = []
+        if item.get("runs"):
+            cursor_x = 0
             base_size = size
             for run in item["runs"]:
                 run_size = max(1, int(float(run.get("font_size", item.get("font_size", 18))) * scale / 72 * preview_font_scale))
@@ -839,21 +892,36 @@ def render_preview(manifest, manifest_path, out_path):
                     run_font = font
                 run_fill = preview_color(run.get("color", item.get("color", "#111111")))
                 baseline = float(run.get("baseline", 0) or 0)
-                run_y = y + int(-baseline / 100000 * base_size)
+                run_y = int(-baseline / 100000 * base_size)
                 run_text = str(run.get("text", ""))
-                draw.text((cursor_x, run_y), run_text, fill=run_fill, font=run_font)
-                cursor_x += int(draw.textlength(run_text, font=run_font))
-            return
+                run_specs.append((cursor_x, run_y, run_text, run_fill, run_font, run_font.getbbox(run_text)))
+                cursor_x += int(round(draw.textlength(run_text, font=run_font)))
+
+        def draw_content(target_draw, origin_x, origin_y):
+            if run_specs:
+                bounds = (
+                    min(spec[0] + spec[5][0] for spec in run_specs),
+                    min(spec[1] + spec[5][1] for spec in run_specs),
+                    max(spec[0] + spec[5][2] for spec in run_specs),
+                    max(spec[1] + spec[5][3] for spec in run_specs),
+                )
+                text_x, text_y = aligned_origin(bounds, origin_x, origin_y)
+                for run_x, run_y, run_text, run_fill, run_font, _run_bounds in run_specs:
+                    target_draw.text((text_x + run_x, text_y + run_y), run_text, fill=run_fill, font=run_font)
+                return
+            bounds = target_draw.multiline_textbbox((0, 0), preview_text, font=font, spacing=4, align=align)
+            text_x, text_y = aligned_origin(bounds, origin_x, origin_y)
+            target_draw.multiline_text((text_x, text_y), preview_text, fill=fill, font=font, spacing=4, align=align)
+
         if rotation:
-            layer_w = max(1, int(item.get("width", 1) * scale))
-            layer_h = max(1, int(item.get("height", 0.4) * scale))
-            layer = Image.new("RGBA", (layer_w, layer_h), (0, 0, 0, 0))
-            layer_draw = ImageDraw.Draw(layer)
-            layer_draw.multiline_text((0, 0), preview_text, fill=fill, font=font, spacing=4, align=align)
+            layer = Image.new("RGBA", (box_width, box_height), (0, 0, 0, 0))
+            draw_content(ImageDraw.Draw(layer), 0, 0)
             rotated = layer.rotate(-rotation, expand=True)
-            canvas.paste(rotated, (x, y), rotated)
+            paste_x = box_x + (box_width - rotated.width) // 2
+            paste_y = box_y + (box_height - rotated.height) // 2
+            canvas.paste(rotated, (paste_x, paste_y), rotated)
             return
-        draw.multiline_text((x, y), preview_text, fill=fill, font=font, spacing=4, align=align)
+        draw_content(draw, box_x, box_y)
 
     layered = []
     for index, item in enumerate(manifest.get("shapes", [])):

--- a/skills/image-to-editable-ppt/cli/editppt/runtime/validate_pptx.py
+++ b/skills/image-to-editable-ppt/cli/editppt/runtime/validate_pptx.py
@@ -8,7 +8,7 @@ import zipfile
 from pathlib import Path
 from xml.etree import ElementTree as ET
 
-from build_pptx_from_manifest import normalize_manifest
+from build_pptx_from_manifest import TEXT_ALIGNMENTS, TEXT_VERTICAL_ALIGNMENTS, normalize_manifest
 
 
 NS = {
@@ -321,6 +321,24 @@ def quality_contract_violations(manifest):
                         "reason": "roundRect source radius cannot exceed half of the smaller shape dimension",
                     }
                 )
+
+    for index, text_box in enumerate(manifest.get("text_boxes", [])):
+        align = str(text_box.get("align", "left") or "left").strip().lower()
+        if align not in TEXT_ALIGNMENTS:
+            violations.append(
+                {
+                    "field": f"text_boxes[{index}].align",
+                    "reason": "text align must be left, center, right, or the equivalent DrawingML token l, ctr, r",
+                }
+            )
+        valign = str(text_box.get("valign", "top") or "top").strip().lower()
+        if valign not in TEXT_VERTICAL_ALIGNMENTS:
+            violations.append(
+                {
+                    "field": f"text_boxes[{index}].valign",
+                    "reason": "text valign must be top, middle, bottom, or the equivalent DrawingML token t, ctr, b",
+                }
+            )
 
     violations.extend(foreground_asset_contract_violations(manifest))
     return violations

--- a/skills/image-to-editable-ppt/references/manifest-schema.md
+++ b/skills/image-to-editable-ppt/references/manifest-schema.md
@@ -2,6 +2,17 @@
 
 This document describes the responsibilities, owners, and current field contracts for `editppt` run/page JSON files. All key state is advanced by `editppt` commands; page reconstructors write only page-local files.
 
+## Contents
+
+- `deck_manifest.json`
+- `page_jobs.json`
+- `page_request.json`
+- `page_result.json`
+- `pages/page_NNN/validation.json`
+- `pages/page_NNN/manifest.json`
+- `pages/page_NNN/imagegen-jobs.json`
+- `notes_manifest.json`
+
 ## `deck_manifest.json`
 
 Owner: created by `editppt prepare`; `editppt run backend` may update the image backend; `editppt run finalize` reads it and writes completion time.
@@ -186,6 +197,12 @@ Text-size fitting:
 - Keep default fitting enabled for first drafts. Set `fit_text: false` only when the page author has manually calibrated the box and font size.
 - `text_boxes[].box_px` should describe the source text bounds plus modest padding. Do not use an entire card, chart, table cell group, or unrelated container as the text box, because the fitter can only infer size from the box it receives.
 - Optional tuning fields are `min_font_size`, `max_font_size`, `text_fit_safety`, and `line_height`.
+
+Text alignment:
+
+- `text_boxes[].align` accepts `left`, `center`, or `right` (default `left`). The equivalent DrawingML tokens `l`, `ctr`, and `r` are also accepted.
+- `text_boxes[].valign` accepts `top`, `middle`, or `bottom` (default `top`); `center` is an alias for `middle`. The equivalent DrawingML tokens `t`, `ctr`, and `b` are also accepted.
+- The deterministic builder translates these manifest values to valid DrawingML enum tokens. Unsupported values are page-contract violations instead of silently falling back to an application default.
 
 `text_inventory` may be a list of strings or a list of structured objects. In structured objects, the fields used for exact text validation are `text`, `required_text`, `items`, or `texts`; fields such as `id`, `decision`, `description`, and `note` are only records and are not used for exact text matching. Example:
 

--- a/skills/image-to-editable-ppt/references/page-decision-tree.md
+++ b/skills/image-to-editable-ppt/references/page-decision-tree.md
@@ -223,6 +223,8 @@ A readable character stroke belongs only to its native text box — never draw t
 
 Preserve grouping relationships (icon + circular base, badge + number, speech bubble + text, hand-drawn arrow + annotation, card background + title + chart + labels).
 
+For native text centered inside a badge or circular base, reuse the base shape's exact `box_px` for the text box and use the centered horizontal and vertical alignment defined in `manifest-schema.md` under "Text alignment." A separate tight ink box drifts as font metrics change and is not a stable grouping relationship.
+
 Recommended z-index:
 
 - clean background/base: 0
@@ -267,6 +269,7 @@ Shapes and layers:
 - Corners follow 3.4; large container corners, table borders, and card borders align with the source. Corner misclassification is a current-page fix, not a low-risk warning.
 - No text stroke is redrawn as a decorative shape (3.5).
 - Dashboards, tables, cards, and charts are decomposed per 1.4, never screenshotted wholesale.
+- Badge and circular-number groups follow the shared-box centering rule in 3.6.
 - z-index follows 3.6; no text or key object is covered.
 
 ## Fix versus Warning

--- a/tests/test_quality_contracts.py
+++ b/tests/test_quality_contracts.py
@@ -144,6 +144,23 @@ class QualityContractTest(unittest.TestCase):
         )
         self.assertEqual(["市场概览", "4280 万", "扩张", "续约"], required)
 
+    def test_invalid_text_alignment_is_a_contract_violation(self):
+        manifest = base_manifest()
+        manifest["text_boxes"] = [
+            {
+                "text": "1",
+                "box_px": [0, 0, 40, 40],
+                "align": "sideways",
+                "valign": "floating",
+            }
+        ]
+
+        violations = quality_contract_violations(manifest)
+        fields = {item["field"] for item in violations}
+
+        self.assertIn("text_boxes[0].align", fields)
+        self.assertIn("text_boxes[0].valign", fields)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_slide_layout.py
+++ b/tests/test_slide_layout.py
@@ -1,14 +1,53 @@
 import sys
+import tempfile
 import unittest
 from pathlib import Path
+
+from PIL import Image
 
 
 ROOT = Path(__file__).resolve().parents[1]
 RUNTIME_DIR = ROOT / "skills/image-to-editable-ppt/cli/editppt/runtime"
 sys.path.insert(0, str(RUNTIME_DIR))
 
-from build_pptx_from_manifest import content_box_for_manifest, emu, normalize_manifest, px_to_inches, slide_size_type  # noqa: E402
+from build_pptx_from_manifest import (  # noqa: E402
+    content_box_for_manifest,
+    emu,
+    normalize_manifest,
+    px_to_inches,
+    render_preview,
+    slide_size_type,
+    text_box_xml,
+)
 from prepare_deck_run import fit_content_box, slide_for_source  # noqa: E402
+
+
+def scalable_test_font():
+    candidates = (
+        "/System/Library/Fonts/Supplemental/Arial.ttf",
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+        "/usr/share/fonts/truetype/liberation2/LiberationSans-Regular.ttf",
+    )
+    return next((path for path in candidates if Path(path).exists()), None)
+
+
+def preview_ink_center(manifest):
+    with tempfile.TemporaryDirectory() as tmp:
+        preview_path = Path(tmp) / "preview.png"
+        render_preview(manifest, Path(tmp) / "manifest.json", preview_path)
+        image = Image.open(preview_path).convert("RGB")
+
+    dark_pixels = [
+        (x, y)
+        for y in range(image.height)
+        for x in range(image.width)
+        if max(image.getpixel((x, y))) < 128
+    ]
+    if not dark_pixels:
+        return None
+    xs = [point[0] for point in dark_pixels]
+    ys = [point[1] for point in dark_pixels]
+    return (min(xs) + max(xs)) / 2, (min(ys) + max(ys)) / 2
 
 
 class SlideLayoutTest(unittest.TestCase):
@@ -117,6 +156,110 @@ class SlideLayoutTest(unittest.TestCase):
 
         self.assertGreater(normalized["text_boxes"][0]["font_size"], 10)
         self.assertLessEqual(normalized["text_boxes"][0]["font_size"], 18)
+
+    def test_text_box_alignment_uses_drawingml_enum_values(self):
+        xml = text_box_xml(
+            2,
+            {
+                "text": "1",
+                "left": 0,
+                "top": 0,
+                "width": 1,
+                "height": 1,
+                "align": "center",
+                "valign": "middle",
+            },
+        )
+
+        self.assertIn('algn="ctr"', xml)
+        self.assertIn('anchor="ctr"', xml)
+        self.assertNotIn('algn="center"', xml)
+        self.assertNotIn('anchor="middle"', xml)
+
+    def test_preview_centers_text_inside_its_box(self):
+        manifest = {
+            "source": {"width_px": 200, "height_px": 200},
+            "slide": {"width": 2, "height": 2, "background": "#ffffff"},
+            "content_box": {"left": 0, "top": 0, "width": 2, "height": 2},
+            "preview_scale": 100,
+            "text_boxes": [
+                {
+                    "text": "1",
+                    "box_px": [50, 50, 100, 100],
+                    "font_size": 48,
+                    "fit_text": False,
+                    "color": "#000000",
+                    "align": "center",
+                    "valign": "middle",
+                }
+            ],
+        }
+
+        ink_center = preview_ink_center(manifest)
+        self.assertIsNotNone(ink_center)
+        ink_center_x, ink_center_y = ink_center
+
+        self.assertAlmostEqual(100, ink_center_x, delta=5)
+        self.assertAlmostEqual(100, ink_center_y, delta=5)
+
+    def test_preview_centers_mixed_size_runs_inside_their_box(self):
+        preview_font = scalable_test_font()
+        self.assertIsNotNone(preview_font)
+        manifest = {
+            "source": {"width_px": 200, "height_px": 200},
+            "slide": {"width": 2, "height": 2, "background": "#ffffff"},
+            "content_box": {"left": 0, "top": 0, "width": 2, "height": 2},
+            "preview_scale": 100,
+            "text_boxes": [
+                {
+                    "runs": [
+                        {"text": "1", "font_size": 72},
+                        {"text": "A", "font_size": 12},
+                    ],
+                    "box_px": [50, 50, 100, 100],
+                    "font_size": 18,
+                    "fit_text": False,
+                    "preview_font": preview_font,
+                    "color": "#000000",
+                    "align": "center",
+                    "valign": "middle",
+                }
+            ],
+        }
+
+        ink_center = preview_ink_center(manifest)
+        self.assertIsNotNone(ink_center)
+        ink_center_x, ink_center_y = ink_center
+
+        self.assertAlmostEqual(100, ink_center_x, delta=8)
+        self.assertAlmostEqual(100, ink_center_y, delta=8)
+
+    def test_preview_rotates_centered_text_around_the_box_center(self):
+        manifest = {
+            "source": {"width_px": 200, "height_px": 200},
+            "slide": {"width": 2, "height": 2, "background": "#ffffff"},
+            "content_box": {"left": 0, "top": 0, "width": 2, "height": 2},
+            "preview_scale": 100,
+            "text_boxes": [
+                {
+                    "text": "1",
+                    "box_px": [50, 50, 100, 100],
+                    "font_size": 48,
+                    "fit_text": False,
+                    "color": "#000000",
+                    "align": "center",
+                    "valign": "middle",
+                    "rotation": 45,
+                }
+            ],
+        }
+
+        ink_center = preview_ink_center(manifest)
+        self.assertIsNotNone(ink_center)
+        ink_center_x, ink_center_y = ink_center
+
+        self.assertAlmostEqual(100, ink_center_x, delta=8)
+        self.assertAlmostEqual(100, ink_center_y, delta=8)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Translate manifest text alignment values to valid DrawingML enum tokens.
- Center preview text inside its full text box, including mixed-size runs and rotated text.
- Require circular badge labels to reuse the badge shape box for stable centering.
- Reject unsupported horizontal and vertical alignment values during validation.

## User-visible changes

- Fixes PowerPoint text boxes whose `center` / `middle` values were written as invalid OOXML tokens.
- Keeps circular badge numbers horizontally and vertically centered in both previews and generated PPTX files.

## Root cause

The manifest used readable alignment names while DrawingML requires enum tokens such as `ctr`. The preview renderer also drew text from the box origin instead of positioning the rendered ink within the full box.

## Changelog

- [x] Updated `CHANGELOG.md`
- [ ] Not needed: internal-only change

## Verification

- `python3 -m compileall -q skills/image-to-editable-ppt/cli/editppt tests`
- `python3 -m unittest discover -s tests` — 76 tests passed
- Generated PPTX smoke test confirmed `algn="ctr"` and `anchor="ctr"` for circular badge numbers.
