### PR TITLE
feat: preserve native objects in hybrid pptx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ## Unreleased
 
+### Features
+
+- Preserve existing native PowerPoint objects for supported mixed-content PPTX input and rebuild only one embedded picture region per slide before merging the editable objects back into the original package. (#21)
+
 ### Documentation
 
 - Fix README rendering for the Codex Full Access recommendation callout.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![Image to Editable PPT 项目概览](assets/image-to-editable-ppt-overview.png)
 
-一个用于把图片、PDF、图片版PPT 转成可编辑 PowerPoint 的 skill。它先把输入归一化为逐页任务，再重建为 `.pptx`：可读文字尽量恢复为原生文本框，简单几何尽量恢复为 PowerPoint 形状，复杂视觉元素保留为带来源记录的独立图片资产。
+一个用于把图片、PDF、图片版或混合元素 PPT 转成可编辑 PowerPoint 的 skill。它先把输入归一化为逐页任务，再重建为 `.pptx`：已有的原生 PPT 元素会尽量原样保留，只重建扁平图片区域；可读文字尽量恢复为原生文本框，简单几何尽量恢复为 PowerPoint 形状，复杂视觉元素保留为带来源记录的独立图片资产。
 
 它适合把截图式或图片式幻灯片变成更容易二次编辑的 PPT，让文字、简单形状和视觉素材尽量分开调整。
 
@@ -67,6 +67,7 @@
 - 文字大小与位置由测量驱动：prepare 阶段为每页生成文字标注（框坐标 + 字号 + 字号分组），模型按测量值还原文字，同级文字字号自动保持一致。
 - 多张图片按提供顺序生成页面；PDF 和 `.pptx` 保留原页码顺序。
 - `.pptx` 输入的页面备注会复制到输出对应页，备注内容不改动。
+- 对“原生 PPT 元素 + 单个嵌入图片区域”的混合页面，保留原生对象、母版和包结构，只把图片区域交给页面重建流程并回填到原层级。
 - 根据具体页面情况决定是否通过已确认 image backend 做图片分层抽取；需要时用稀疏 asset sheet 合并前景素材，优先把图标放在一个素材板上，并保留充足间隙便于后续分离。
 - 支持复杂视觉页的混合策略：可编辑文字 + 简单形状 + 独立图片资产。
 
@@ -75,6 +76,7 @@
 - 把一张或多张 slide 图片重建成可调整文字和元素位置的 PPT。
 - 把多张图片或多页 PDF 转成一个多页 `.pptx`。
 - 把图片版PPT页面转换为更容易二次编辑的 `.pptx`，并保留原页面备注。
+- 只重建 PPT 中已经扁平化的图片区域，同时保留本来就可编辑的文字、形状和分组。
 - 复刻单页视觉设计，同时保留文本可编辑性。
 - 对比源图与输出页面，定位缺字、错位或资产缺失。
 
@@ -117,6 +119,7 @@
 - 本 skill有着相对复杂的流程控制，Token花费比较高。将一个图片PPT转换成可编辑PPT的成本，**可能是生成图片PPT成本的2-3倍**。
 - 受限于模型基础理解能力和对 skill 的遵循能力，**不保证 gpt-5.5 以下模型的使用效果**。
 - 部分图片元素和文字位置可能会有轻微偏移，**不能保证 100% 复刻原始页面**。
+- 混合 PPTX 首版要求每页恰好有一个嵌入图片；暂不支持同页多图、链接图片，以及裁剪、旋转或翻转过的目标图片。
 
 ## 安装
 
@@ -145,12 +148,12 @@ $image-to-editable-ppt 把 <path-to-image-based.pptx> 转成可编辑 PPT。
 
 skill 通常会完成这些步骤：
 
-1. 创建独立任务目录，把输入归一化为 `pages/page_NNN/source.png`，并写入默认 `editppt image` backend。
+1. 创建独立任务目录，把整页图片或混合 PPTX 中待重建的图片区域归一化为 `pages/page_NNN/source.png`，并写入默认 `editppt image` backend。
 2. 如果只有 1 页，主 agent 先用 `editppt run dispatch --local` 认领页面，再按同一页面 prompt 本地重建；如果有多页，则按 `max_concurrent_pages` 分批分派给 page worker 重建。
 3. 页面重建者（主 agent 本地模式或 page worker）负责自己的页面目录，完成页面重建、自检和 page-local 修正。
 4. 每页创建 manifest，重建可编辑文本、简单形状和图片资产。
 5. 用 `editppt` 命令记录 dispatch、page result 和 accepted 状态。
-6. 主 agent 用 `editppt run finalize` 按页顺序读取已记录的 `manifest.json` 重建最终 `.pptx`，复制 `.pptx` 页面备注，并运行 deck validation。
+6. 主 agent 用 `editppt run finalize` 按页顺序读取已记录的 `manifest.json` 生成最终 `.pptx`；混合 PPTX 会把重建对象替换回原图片位置并保留其他原生对象，随后运行 deck validation。
 
 ## 输出结构
 
@@ -162,6 +165,7 @@ skill 通常会完成这些步骤：
 | 多张图片  | 多页 `.pptx`，每张图片 1 页，按提供顺序排列  |
 | 多页 PDF  | 多页 `.pptx`，PDF 第 N 页对应输出第 N 页     |
 | 图片版PPT | 页数一致的 `.pptx`，原第 N 页对应输出第 N 页 |
+| 混合元素 PPTX | 保留原生对象，只替换每页的扁平图片区域 |
 
 只有 `.pptx` 输入会处理页面备注。备注由主 agent 按页原样复制到输出 PPTX：不翻译、不摘要、不改写，也不交给 page worker 处理。
 

--- a/README_en.md
+++ b/README_en.md
@@ -4,7 +4,7 @@
 
 ![Image to Editable PPT project overview](assets/image-to-editable-ppt-overview.png)
 
-A skill for converting images, PDFs, and image-based PPT files into editable PowerPoint `.pptx` output. It normalizes inputs into per-page jobs, then rebuilds editable text, simple shapes, and positioned visual assets.
+A skill for converting images, PDFs, and image-based or mixed-content PPT files into editable PowerPoint `.pptx` output. Existing native PowerPoint objects are preserved when possible, while only flattened picture regions are reconstructed into editable text, simple shapes, and positioned visual assets.
 
 It is useful when screenshot-like or image-based slides need to become easier to edit again, with text, simple shapes, and visual assets separated where practical.
 
@@ -67,6 +67,7 @@ It is useful when screenshot-like or image-based slides need to become easier to
 - Text sizes and positions are measurement-driven: prepare generates per-page text annotations (box coordinates + font sizes + size groups), and same-level text keeps one consistent size automatically.
 - Keep multiple images in the provided order; preserve PDF and `.pptx` page order.
 - Preserve `.pptx` speaker notes on matching output slides without modifying note text.
+- For mixed slides with native PowerPoint objects plus one embedded picture region, preserve native objects, masters, and package structure while rebuilding only that picture region in place.
 - Decides page by page whether to use the confirmed image backend for visual-layer extraction; when needed, sparse asset sheets group foreground assets, prefer placing icons on one sheet, and keep generous gaps for later splitting.
 - Supports hybrid reconstruction: editable text, simple native shapes, and independent image assets.
 
@@ -75,6 +76,7 @@ It is useful when screenshot-like or image-based slides need to become easier to
 - Rebuild one or more slide images into a PowerPoint deck whose text and element positions can be adjusted.
 - Convert multiple images or a multi-page PDF into a multi-slide `.pptx`.
 - Convert image-based PPT slides into a more editable `.pptx` while preserving source speaker notes.
+- Rebuild only flattened picture regions while retaining text, shapes, and groups that are already editable.
 - Recreate a single-slide visual design while keeping text editable.
 - Compare source pages against output slides to find missing text, alignment drift, or missing assets.
 
@@ -117,6 +119,7 @@ The skill still runs without a token: it falls back to the built-in offline dete
 - This skill has relatively complex flow control and high token usage. The cost of converting an image-based PPT into an editable PPT **may be 2-3x the cost of generating an image-based PPT**.
 - Results are limited by the model's baseline visual understanding and its ability to follow the skill workflow; usage quality is **not guaranteed for models below gpt-5.5**.
 - Some image elements and text positions may shift slightly, so output is **not guaranteed to be a 100% replica of the original page**.
+- The first hybrid-PPTX version requires exactly one embedded picture per slide. Multiple pictures, linked images, and cropped, rotated, or flipped target pictures are not yet supported.
 
 ## Install
 
@@ -145,12 +148,12 @@ $image-to-editable-ppt convert <path-to-image-based.pptx> into an editable Power
 
 The normal workflow is:
 
-1. Create an isolated job folder, normalize inputs into `pages/page_NNN/source.png`, and write the default `editppt image` backend.
+1. Create an isolated job folder, normalize full-page images or the picture region selected from each hybrid PPTX slide into `pages/page_NNN/source.png`, and write the default `editppt image` backend.
 2. If there is exactly 1 page, the main agent first claims it with `editppt run dispatch --local`, then rebuilds it locally from the same page prompt; if there are multiple pages, dispatch them to page workers in `max_concurrent_pages` batches.
 3. The page reconstructor — main-agent local mode or page worker — owns one page directory and completes reconstruction, self-check, and page-local correction there.
 4. Build one page manifest per page with editable text, simple shapes, and positioned image assets.
 5. Use `editppt` commands to record dispatches, page results, and accepted status.
-6. Use `editppt run finalize` to rebuild the final `.pptx` from recorded `manifest.json` files in page order, copy `.pptx` speaker notes when present, and run deck validation.
+6. Use `editppt run finalize` to build the final `.pptx` from recorded `manifest.json` files in page order. For hybrid PPTX input, replace the original picture with rebuilt objects while preserving other native objects, then run deck validation.
 
 ## Output Layout
 
@@ -162,6 +165,7 @@ Output is always a PowerPoint `.pptx` file:
 | Multiple images | Multi-slide `.pptx`, one slide per image, in the provided order |
 | Multi-page PDF | Multi-slide `.pptx`; PDF page N maps to output slide N |
 | Image-based PPT | `.pptx` with the same slide count; source slide N maps to output slide N |
+| Mixed-content PPTX | Preserve native objects and replace only each slide's flattened picture region |
 
 Speaker notes are handled only for `.pptx` input. The parent agent copies notes to matching output slides unchanged: no translation, summarization, rewriting, or page-subagent processing.
 

--- a/skills/image-to-editable-ppt/SKILL.md
+++ b/skills/image-to-editable-ppt/SKILL.md
@@ -8,7 +8,7 @@ description: Rebuild slide images, image-based or scanned PPT/PPTX files, and PD
 
 This skill rebuilds visual slide inputs into object-level editable PowerPoint `.pptx` files.
 
-Inputs can be a single image, multiple images, a PDF, or an image-based PPT/PPTX. The output is always `.pptx`. The goal is not to wrap a full-slide screenshot inside PowerPoint; the goal is to use the `editppt` runtime and page-level prompts to decompose, reconstruct, validate, and assemble editable slides.
+Inputs can be a single image, multiple images, a PDF, an image-based PPT/PPTX, or a supported mixed-content PPTX. The output is always `.pptx`. The goal is not to wrap a full-slide screenshot inside PowerPoint; the goal is to use the `editppt` runtime and page-level prompts to decompose, reconstruct, validate, and assemble editable slides. For supported mixed-content PPTX input, native objects stay in the source package and only the selected flattened picture region is reconstructed.
 
 ## References
 
@@ -26,6 +26,7 @@ These parent-level rules are stated once here; page-level rules live in the refe
 
 - The `editppt` CLI is a required runtime surface. If `editppt --help` fails, install it first by following the Pre-Run Check in `references/cli-helper.md` before doing anything else.
 - First run `editppt prepare <input...>` to create a run directory. After that, all key state transitions are advanced only through `editppt` commands; never hand-write run/page state JSON. This keeps run state deterministic and resumable.
+- For PPTX input, accept `prepare`'s detected mode. Image-only slides use the normal page reconstruction path; `hybrid-pptx` pages preserve the source package and carry one runtime-selected picture replacement target per slide. Do not flatten the PPTX to PDF first, because doing so discards native objects that hybrid finalization is designed to preserve.
 - Multi-page inputs are rebuilt by dispatched page workers. A run with exactly one page is rebuilt by the parent agent in local page-reconstructor mode after `editppt run dispatch --local` claims that page. If no subagent capability is available for a multi-page run, stop and report this to the user; do not degrade into parent-agent reconstruction for multi-page input.
 - The parent agent must not write any page reconstruction artifact — `manifest.json`, `page.pptx`, `preview.png`, `split_assets_contact.png`, `validation.json`, or `page_result.json` — except in single-page local page-reconstructor mode after `editppt run dispatch --local` has recorded the claim. Local mode follows the same page prompt, references, output files, and `run record` validation path as a page worker.
 - All image generation, image editing, background repair, transparent bitmap assets, and asset sheets go through serial `editppt image generate/edit` calls.
@@ -59,6 +60,8 @@ editppt prepare <input...>
 ```
 
 After this completes, there must be a run directory, `deck_manifest.json`, `page_jobs.json`, `notes_manifest.json`, and each page must have `source.png` plus `page_request.json`.
+
+For `hybrid-pptx`, each `source.png` is the embedded picture selected for replacement rather than a render of the whole slide. Its replacement metadata is runtime-owned and defined in `references/manifest-schema.md`; page reconstructors still work only on the local page canvas.
 
 Prepare also writes per-page text hints. Whenever `editppt doctor` or prepare reports that no PaddleOCR token is configured (offline fallback), ask the user once before dispatching any page: a free token from https://aistudio.baidu.com/account/accessToken stored via `editppt config --paddle-ocr-token <token>` makes the hints content-aware and noticeably improves text fidelity, and `editppt run hints <run>` regenerates the current run's hints in place. Tell the user the free personal quota is currently more than enough for this skill — applying is risk-free with no extra cost. Wait for their choice; if they decline or want to proceed, continue with the offline hints and do not ask again.
 
@@ -120,7 +123,7 @@ When `editppt run next <run>` returns the finalize stage:
 editppt run finalize <run>
 ```
 
-`finalize` treats each recorded `pages/page_NNN/manifest.json` as the authoritative source: it rebuilds the final deck from page manifests in page order, then validates the resulting PPTX. `page.pptx` remains a page-level deliverability artifact for record-time checks.
+`finalize` treats each recorded `pages/page_NNN/manifest.json` as the authoritative reconstruction source. Normal runs rebuild the final deck from those manifests in page order. A `hybrid-pptx` run instead replaces each recorded target picture inside the original PPTX package with the manifest objects, preserving all other native slide objects and package parts. It then validates the resulting PPTX. `page.pptx` remains a page-level deliverability artifact for record-time checks.
 
 Deck-level structural QA at this stage:
 

--- a/skills/image-to-editable-ppt/cli/editppt/runtime/_input_normalization.py
+++ b/skills/image-to-editable-ppt/cli/editppt/runtime/_input_normalization.py
@@ -170,6 +170,15 @@ def full_slide_picture_target(zip_file, slide_part, slide_cx, slide_cy):
     slide_root = ET.fromstring(zip_file.read(slide_part))
     if collect_paragraph_text(slide_root):
         raise ValueError(f"{slide_part} contains native text and is not an image-based slide.")
+    shape_tree = slide_root.find(".//p:spTree", NS)
+    native_tags = {
+        f"{{{NS['p']}}}sp",
+        f"{{{NS['p']}}}grpSp",
+        f"{{{NS['p']}}}graphicFrame",
+        f"{{{NS['p']}}}cxnSp",
+    }
+    if shape_tree is not None and any(child.tag in native_tags for child in shape_tree):
+        raise ValueError(f"{slide_part} contains native objects and is not an image-only slide.")
     pictures = slide_root.findall(".//p:pic", NS)
     if len(pictures) != 1:
         raise ValueError(f"{slide_part} must contain exactly one full-slide picture; found {len(pictures)}.")
@@ -194,6 +203,94 @@ def full_slide_picture_target(zip_file, slide_part, slide_cx, slide_cy):
         raise ValueError(f"{slide_part} picture is not full-slide.")
 
     return resolve_target(f"{posixpath.dirname(slide_part)}/_rels/{posixpath.basename(slide_part)}.rels", rel.attrib["Target"])
+
+
+def embedded_picture_target(zip_file, slide_part):
+    """Return the slide's single picture and its replacement metadata.
+
+    Hybrid reconstruction deliberately starts with one picture per slide.  A
+    single picture gives the finalizer an unambiguous OOXML node to replace
+    while every other native object remains untouched, including group peers.
+    """
+    slide_root = ET.fromstring(zip_file.read(slide_part))
+    shape_tree = slide_root.find(".//p:spTree", NS)
+    if shape_tree is None:
+        raise ValueError(f"{slide_part} has no shape tree.")
+    pictures = shape_tree.findall(".//p:pic", NS)
+    if len(pictures) != 1:
+        raise ValueError(f"{slide_part} must contain exactly one picture; found {len(pictures)}.")
+    picture = pictures[0]
+
+    def find_parent(node, wanted):
+        for child in list(node):
+            if child is wanted:
+                return node
+            parent = find_parent(child, wanted)
+            if parent is not None:
+                return parent
+        return None
+
+    picture_parent = find_parent(shape_tree, picture)
+    if picture_parent is None or picture_parent.tag not in {f"{{{NS['p']}}}spTree", f"{{{NS['p']}}}grpSp"}:
+        raise ValueError(f"{slide_part} picture has an unsupported parent container.")
+    blip = picture.find(".//a:blip", NS)
+    if blip is None:
+        raise ValueError(f"{slide_part} picture has no embedded image.")
+    rel_id = blip.attrib.get(f"{{{NS['r']}}}embed")
+    relationships = slide_relationships(zip_file, slide_part)
+    rel = relationships.get(rel_id)
+    if rel is None or not rel.attrib.get("Type", "").endswith("/image") or rel.attrib.get("TargetMode") == "External":
+        raise ValueError(f"{slide_part} picture relationship is not an embedded image.")
+
+    xfrm = picture.find("p:spPr/a:xfrm", NS)
+    off = xfrm.find("a:off", NS) if xfrm is not None else None
+    ext = xfrm.find("a:ext", NS) if xfrm is not None else None
+    if off is None or ext is None:
+        raise ValueError(f"{slide_part} picture has no placement transform.")
+    if xfrm.attrib.get("rot") not in (None, "0") or xfrm.attrib.get("flipH") == "1" or xfrm.attrib.get("flipV") == "1":
+        raise ValueError(f"{slide_part} picture uses rotation or flipping, which hybrid replacement does not yet support.")
+    crop = picture.find("p:blipFill/a:srcRect", NS)
+    if crop is not None and any(int(crop.attrib.get(side, 0)) for side in ("l", "t", "r", "b")):
+        raise ValueError(f"{slide_part} picture uses cropping, which hybrid replacement does not yet support.")
+
+    c_nv_pr = picture.find("p:nvPicPr/p:cNvPr", NS)
+    if c_nv_pr is None or not c_nv_pr.attrib.get("id"):
+        raise ValueError(f"{slide_part} picture has no stable shape id.")
+    rels_name = f"{posixpath.dirname(slide_part)}/_rels/{posixpath.basename(slide_part)}.rels"
+    image_part = resolve_target(rels_name, rel.attrib["Target"])
+    return image_part, {
+        "slide_part": slide_part,
+        "picture_shape_id": int(c_nv_pr.attrib["id"]),
+        "picture_name": c_nv_pr.attrib.get("name", ""),
+        "relationship_id": rel_id,
+        "z_index": list(picture_parent).index(picture),
+        "frame_emu": {
+            "x": int(off.attrib.get("x", 0)),
+            "y": int(off.attrib.get("y", 0)),
+            "cx": int(ext.attrib.get("cx", 0)),
+            "cy": int(ext.attrib.get("cy", 0)),
+        },
+    }
+
+
+def extract_hybrid_pptx_pages(pptx_path, pages_dir):
+    outputs = []
+    targets = []
+    with zipfile.ZipFile(pptx_path) as z:
+        names = set(z.namelist())
+        slide_cx, slide_cy = slide_size_from_pptx(z)
+        for index, slide_part in enumerate(slide_parts_from_pptx(z), start=1):
+            image_part, target = embedded_picture_target(z, slide_part)
+            if image_part not in names:
+                raise ValueError(f"{slide_part} references missing image part: {image_part}")
+            page_dir = pages_dir / f"page_{index:03d}"
+            page_dir.mkdir(parents=True, exist_ok=True)
+            out = page_dir / "source.png"
+            with Image.open(io.BytesIO(z.read(image_part))) as image:
+                image.convert("RGB").save(out)
+            outputs.append(out)
+            targets.append(target)
+    return outputs, targets, {"width_emu": slide_cx, "height_emu": slide_cy}
 
 
 def extract_image_based_pptx_pages(pptx_path, pages_dir):
@@ -256,10 +353,10 @@ def convert_ppt_to_pptx(input_path, out_dir):
     return pptxs[0]
 
 
-def page_record(job_dir, page_index, source, input_path, source_page):
+def page_record(job_dir, page_index, source, input_path, source_page, replacement_target=None):
     page_dir = source.parent
     rel_page_dir = page_dir.relative_to(job_dir).as_posix()
-    return {
+    record = {
         "page_index": page_index,
         "source_page": source_page,
         "source_image": source.relative_to(job_dir).as_posix(),
@@ -269,6 +366,9 @@ def page_record(job_dir, page_index, source, input_path, source_page):
         "input": Path(input_path).name,
         "agent_status": "pending",
     }
+    if replacement_target:
+        record["replacement_target"] = replacement_target
+    return record
 
 
 def default_job_dir(out_root, input_paths):
@@ -295,6 +395,7 @@ def normalize_inputs(inputs, out_root="output/image-to-editable-ppt", job_dir=No
     pages = []
     notes = []
     input_type = "images"
+    source_slide = None
 
     if len(copied) == 1 and copied[0].suffix.lower() == ".pdf":
         input_type = "pdf"
@@ -307,11 +408,15 @@ def normalize_inputs(inputs, out_root="output/image-to-editable-ppt", job_dir=No
             try:
                 sources = extract_image_based_pptx_pages(copied[0], pages_dir)
             except ValueError as exc:
-                raise SystemExit(
-                    "Unsupported PPTX for the lightweight path: "
-                    f"{exc} This skill accepts image-based PPTX files through lightweight extraction. "
-                    "Convert native/complex PPTX slides to PDF or page images first."
-                ) from exc
+                try:
+                    sources, targets, source_slide = extract_hybrid_pptx_pages(copied[0], pages_dir)
+                    input_type = "hybrid-pptx"
+                except ValueError as hybrid_exc:
+                    raise SystemExit(
+                        "Unsupported PPTX: lightweight extraction failed because "
+                        f"{exc} Hybrid extraction also failed because {hybrid_exc} "
+                        "Hybrid mode currently supports exactly one embedded, uncropped, unrotated picture per slide."
+                    ) from hybrid_exc
         else:
             input_type = "ppt"
             with tempfile.TemporaryDirectory() as tmp:
@@ -322,7 +427,17 @@ def normalize_inputs(inputs, out_root="output/image-to-editable-ppt", job_dir=No
                     shutil.copy2(source_pptx, input_dir / source_pptx.name)
                 rendered_pdf = convert_office_to_pdf(copied[0], tmp_dir)
                 sources = render_pdf_pages(rendered_pdf, pages_dir, args.dpi)
-        pages = [page_record(job_dir, i, source, copied[0], i) for i, source in enumerate(sources, start=1)]
+        pages = [
+            page_record(
+                job_dir,
+                i,
+                source,
+                copied[0],
+                i,
+                targets[i - 1] if input_type == "hybrid-pptx" else None,
+            )
+            for i, source in enumerate(sources, start=1)
+        ]
     elif suffixes <= IMG_EXTS:
         input_type = "image" if len(copied) == 1 else "images"
         for i, src in enumerate(copied, start=1):
@@ -350,6 +465,8 @@ def normalize_inputs(inputs, out_root="output/image-to-editable-ppt", job_dir=No
         "output": default_output_name(copied),
         "validation": "validation.json",
     }
+    if source_slide:
+        deck_manifest["source_slide"] = source_slide
     deck_manifest_path = job_dir / "deck_manifest.json"
     deck_manifest_path.write_text(json.dumps(deck_manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     return deck_manifest_path

--- a/skills/image-to-editable-ppt/cli/editppt/runtime/build_pptx_from_manifest.py
+++ b/skills/image-to-editable-ppt/cli/editppt/runtime/build_pptx_from_manifest.py
@@ -3,6 +3,7 @@ import argparse
 import html
 import json
 import math
+import posixpath
 import re
 import subprocess
 import sys
@@ -10,6 +11,7 @@ import tempfile
 import zipfile
 from copy import deepcopy
 from pathlib import Path
+from xml.etree import ElementTree as ET
 
 
 EMU_PER_INCH = 914400
@@ -664,6 +666,9 @@ def deck_slide_size(deck, page_entries):
 def write_deck(deck, page_entries, out_path, notes_entries):
     if not page_entries:
         raise ValueError("Deck has no pages")
+    if deck.get("input_type") == "hybrid-pptx":
+        write_hybrid_deck(deck, page_entries, out_path)
+        return
     width, height = deck_slide_size(deck, page_entries)
     out = Path(out_path)
     out.parent.mkdir(parents=True, exist_ok=True)
@@ -697,6 +702,180 @@ def write_deck(deck, page_entries, out_path, notes_entries):
                 z.writestr(f"ppt/notesSlides/_rels/notesSlide{notes_index}.xml.rels", notes_rels_xml(slide_index))
 
 
+def _fragment_element(xml):
+    wrapper = (
+        f'<root xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" '
+        f'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" '
+        f'xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">{xml}</root>'
+    )
+    return list(ET.fromstring(wrapper))[0]
+
+
+def _next_relationship_id(root):
+    used = {rel.attrib.get("Id", "") for rel in root}
+    number = 1
+    while f"rId{number}" in used:
+        number += 1
+    return f"rId{number}"
+
+
+def _find_parent(root, wanted):
+    for child in list(root):
+        if child is wanted:
+            return root
+        parent = _find_parent(child, wanted)
+        if parent is not None:
+            return parent
+    return None
+
+
+def _hybrid_manifest(deck, entry):
+    manifest = deepcopy(entry["manifest"])
+    target = entry["page"]["replacement_target"]
+    frame = target["frame_emu"]
+    manifest["slide"] = dict(deck["slide"])
+    manifest["content_box"] = {
+        "left": frame["x"] / EMU_PER_INCH,
+        "top": frame["y"] / EMU_PER_INCH,
+        "width": frame["cx"] / EMU_PER_INCH,
+        "height": frame["cy"] / EMU_PER_INCH,
+    }
+    return normalize_manifest(manifest)
+
+
+def _add_content_type_default(content_types, extension, content_type):
+    namespace = "http://schemas.openxmlformats.org/package/2006/content-types"
+    for node in content_types.findall(f"{{{namespace}}}Default"):
+        if node.attrib.get("Extension", "").lower() == extension.lower():
+            return
+    ET.SubElement(content_types, f"{{{namespace}}}Default", Extension=extension, ContentType=content_type)
+
+
+def _resolve_relationship_target(rels_part, target):
+    rels_dir = posixpath.dirname(rels_part)
+    source_dir = posixpath.dirname(rels_dir) if posixpath.basename(rels_dir) == "_rels" else rels_dir
+    return posixpath.normpath(posixpath.join(source_dir, target))
+
+
+def write_hybrid_deck(deck, page_entries, out_path):
+    """Replace one picture per source slide while preserving the source PPTX package."""
+    root = Path(deck.get("job_dir", ".")).resolve()
+    source = Path(deck.get("inputs", [""])[0])
+    if not source.is_absolute():
+        source = root / source
+    if not source.exists():
+        raise ValueError(f"Hybrid source PPTX does not exist: {source}")
+
+    ET.register_namespace("a", "http://schemas.openxmlformats.org/drawingml/2006/main")
+    ET.register_namespace("p", "http://schemas.openxmlformats.org/presentationml/2006/main")
+    ET.register_namespace("r", "http://schemas.openxmlformats.org/officeDocument/2006/relationships")
+    ET.register_namespace("", REL_NS)
+    p_ns = "http://schemas.openxmlformats.org/presentationml/2006/main"
+
+    with zipfile.ZipFile(source) as original:
+        parts = {name: original.read(name) for name in original.namelist()}
+    additions = {}
+    removed_media = set()
+    content_types = ET.fromstring(parts["[Content_Types].xml"])
+
+    for page_index, entry in enumerate(page_entries, start=1):
+        target = entry["page"].get("replacement_target")
+        if not target:
+            raise ValueError(f"Hybrid page {page_index} has no replacement_target")
+        slide_part = target["slide_part"]
+        rels_part = f"{posixpath.dirname(slide_part)}/_rels/{posixpath.basename(slide_part)}.rels"
+        slide_root = ET.fromstring(parts[slide_part])
+        shape_tree = slide_root.find(f".//{{{p_ns}}}spTree")
+        if shape_tree is None:
+            raise ValueError(f"{slide_part} has no shape tree")
+
+        picture = None
+        for candidate in shape_tree.findall(f".//{{{p_ns}}}pic"):
+            c_nv_pr = candidate.find(f"{{{p_ns}}}nvPicPr/{{{p_ns}}}cNvPr")
+            if c_nv_pr is not None and int(c_nv_pr.attrib.get("id", -1)) == int(target["picture_shape_id"]):
+                picture = candidate
+                break
+        if picture is None:
+            raise ValueError(f"{slide_part} no longer contains picture shape id {target['picture_shape_id']}")
+        picture_parent = _find_parent(shape_tree, picture)
+        if picture_parent is None:
+            raise ValueError(f"{slide_part} picture shape id {target['picture_shape_id']} has no parent")
+        insert_at = list(picture_parent).index(picture)
+        picture_parent.remove(picture)
+
+        rel_root = ET.fromstring(parts[rels_part])
+        target_rel_id = target.get("relationship_id")
+        relationship_still_used = any(target_rel_id in node.attrib.values() for node in slide_root.iter())
+        if not relationship_still_used:
+            for relationship in list(rel_root):
+                if relationship.attrib.get("Id") == target_rel_id:
+                    if relationship.attrib.get("TargetMode") != "External" and relationship.attrib.get("Target"):
+                        removed_media.add(_resolve_relationship_target(rels_part, relationship.attrib["Target"]))
+                    rel_root.remove(relationship)
+
+        manifest = _hybrid_manifest(deck, entry)
+        layered = []
+        for index, item in enumerate(manifest.get("shapes", [])):
+            layered.append((float(item.get("z_index", 100)), index, "shape", item))
+        for index, item in enumerate(manifest.get("images", [])):
+            layered.append((float(item.get("z_index", 200)), index, "image", item))
+        for index, item in enumerate(manifest.get("text_boxes", [])):
+            layered.append((float(item.get("z_index", 300)), index, "text", item))
+
+        existing_ids = [int(node.attrib["id"]) for node in slide_root.findall(f".//{{{p_ns}}}cNvPr") if node.attrib.get("id", "").isdigit()]
+        next_shape_id = max(existing_ids, default=1) + 1
+        manifest_base = Path(entry["manifest_path"]).resolve().parent
+        generated = []
+        for _z, _order, kind, item in sorted(layered, key=lambda value: (value[0], value[1])):
+            if kind == "shape":
+                generated.append(_fragment_element(shape_xml(next_shape_id, item)))
+            elif kind == "text":
+                generated.append(_fragment_element(text_box_xml(next_shape_id, item)))
+            else:
+                rel_id = _next_relationship_id(rel_root)
+                src = Path(item["path"])
+                if not src.is_absolute():
+                    src = manifest_base / src
+                extension = image_ext(src)
+                media_part = f"ppt/media/editppt_hybrid_{page_index:03d}_{_order + 1:03d}{extension}"
+                additions[media_part] = src.read_bytes()
+                target_path = posixpath.relpath(media_part, posixpath.dirname(slide_part))
+                ET.SubElement(
+                    rel_root,
+                    f"{{{REL_NS}}}Relationship",
+                    Id=rel_id,
+                    Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",
+                    Target=target_path,
+                )
+                _add_content_type_default(content_types, extension.lstrip("."), content_type_for(src))
+                generated.append(_fragment_element(image_xml(next_shape_id, rel_id, item)))
+            next_shape_id += 1
+
+        for offset, element in enumerate(generated):
+            picture_parent.insert(insert_at + offset, element)
+        parts[slide_part] = ET.tostring(slide_root, encoding="utf-8", xml_declaration=True)
+        parts[rels_part] = ET.tostring(rel_root, encoding="utf-8", xml_declaration=True)
+
+    parts["[Content_Types].xml"] = ET.tostring(content_types, encoding="utf-8", xml_declaration=True)
+    referenced_parts = set()
+    for rels_part, data in parts.items():
+        if not rels_part.endswith(".rels"):
+            continue
+        for relationship in ET.fromstring(data):
+            target = relationship.attrib.get("Target")
+            if target and relationship.attrib.get("TargetMode") != "External":
+                referenced_parts.add(_resolve_relationship_target(rels_part, target))
+    for media_part in removed_media - referenced_parts:
+        parts.pop(media_part, None)
+    out = Path(out_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as result:
+        for name, data in parts.items():
+            result.writestr(name, data)
+        for name, data in additions.items():
+            result.writestr(name, data)
+
+
 def page_entries_from_deck_manifest(deck_manifest_path):
     deck_path = Path(deck_manifest_path).resolve()
     deck = json.loads(deck_path.read_text(encoding="utf-8"))
@@ -707,7 +886,7 @@ def page_entries_from_deck_manifest(deck_manifest_path):
         if not manifest_path.is_absolute():
             manifest_path = root / manifest_path
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-        entries.append({"manifest": manifest, "manifest_path": manifest_path})
+        entries.append({"manifest": manifest, "manifest_path": manifest_path, "page": page})
     notes_path = deck.get("notes_manifest")
     notes_entries = []
     if notes_path:

--- a/skills/image-to-editable-ppt/cli/editppt/runtime/prepare_deck_run.py
+++ b/skills/image-to-editable-ppt/cli/editppt/runtime/prepare_deck_run.py
@@ -66,6 +66,13 @@ def page_source_size(run_dir, page):
 
 
 def deck_slide_layout(run_dir, deck):
+    source_slide = deck.get("source_slide")
+    if deck.get("input_type") == "hybrid-pptx" and source_slide:
+        return {
+            "width": float(source_slide["width_emu"]) / 914400,
+            "height": float(source_slide["height_emu"]) / 914400,
+            "size_mode": "source-pptx",
+        }
     first_page = deck.get("pages", [{}])[0]
     _source, width_px, height_px = page_source_size(run_dir, first_page)
     return slide_for_source(width_px, height_px)
@@ -74,9 +81,11 @@ def deck_slide_layout(run_dir, deck):
 def page_request(run_dir, deck, page):
     page_dir = (run_dir / page["page_dir"]).resolve()
     source, width_px, height_px = page_source_size(run_dir, page)
-    slide = dict(deck["slide"])
+    # A hybrid worker rebuilds the extracted picture on its own local canvas.
+    # The finalizer maps that canvas back into the original picture frame.
+    slide = slide_for_source(width_px, height_px) if page.get("replacement_target") else dict(deck["slide"])
     page_id = page["page_id"]
-    return {
+    request = {
         "schema_version": 1,
         "run_id": deck["run_id"],
         "page_id": page_id,
@@ -105,6 +114,9 @@ def page_request(run_dir, deck, page):
             "page_result": str(page_dir / "page_result.json"),
         },
     }
+    if page.get("replacement_target"):
+        request["replacement_target"] = page["replacement_target"]
+    return request
 
 
 def write_page_jobs(run_dir, deck):

--- a/skills/image-to-editable-ppt/references/cli-helper.md
+++ b/skills/image-to-editable-ppt/references/cli-helper.md
@@ -112,7 +112,7 @@ editppt prepare input.png
 editppt prepare input.pdf
 ```
 
-Purpose: normalize a single image, multiple images, a PDF, or an image-based PPTX into a run directory and generate `deck_manifest.json`, `page_jobs.json`, `notes_manifest.json`, plus per-page `pages/page_NNN/source.png`, `page_request.json`, and text hints.
+Purpose: normalize a single image, multiple images, a PDF, an image-based PPTX, or a supported mixed-content PPTX into a run directory and generate `deck_manifest.json`, `page_jobs.json`, `notes_manifest.json`, plus per-page `pages/page_NNN/source.png`, `page_request.json`, and text hints. Mixed-content PPTX input is marked `hybrid-pptx`; its page source is the one embedded picture selected for in-place replacement.
 
 When a PaddleOCR token is configured, `prepare` may submit the input pages to PaddleOCR for content-aware text hints. In a sandboxed or approval-gated environment, request network approval up front for this command instead of accepting a DNS/sandbox failure followed by lower-quality `builtin-ink` fallback; see `SKILL.md` Phase 1 for the approval-rejection policy.
 
@@ -156,7 +156,7 @@ Purpose: return a dispatched or recorded page to `pending`, clearing its dispatc
 editppt run finalize <run>
 ```
 
-Purpose: after all pages are recorded, rebuild, validate, and output the final PPTX. Final assembly reads each recorded `pages/page_NNN/manifest.json` in page order; `page.pptx` is a page-local deliverability artifact, not the final assembly input.
+Purpose: after all pages are recorded, rebuild, validate, and output the final PPTX. Final assembly reads each recorded `pages/page_NNN/manifest.json` in page order; for `hybrid-pptx`, it replaces each recorded target picture inside the original package and preserves other native objects. `page.pptx` is a page-local deliverability artifact, not the final assembly input.
 
 ## Page Build Commands
 

--- a/skills/image-to-editable-ppt/references/manifest-schema.md
+++ b/skills/image-to-editable-ppt/references/manifest-schema.md
@@ -2,6 +2,17 @@
 
 This document describes the responsibilities, owners, and current field contracts for `editppt` run/page JSON files. All key state is advanced by `editppt` commands; page reconstructors write only page-local files.
 
+## Contents
+
+- [`deck_manifest.json`](#deck_manifestjson)
+- [`page_jobs.json`](#page_jobsjson)
+- [`page_request.json`](#page_requestjson)
+- [`page_result.json`](#page_resultjson)
+- [`pages/page_NNN/validation.json`](#pagespage_nnnvalidationjson)
+- [`pages/page_NNN/manifest.json`](#pagespage_nnnmanifestjson)
+- [`pages/page_NNN/imagegen-jobs.json`](#pagespage_nnnimagegen-jobsjson)
+- [`notes_manifest.json`](#notes_manifestjson)
+
 ## `deck_manifest.json`
 
 Owner: created by `editppt prepare`; `editppt run backend` may update the image backend; `editppt run finalize` reads it and writes completion time.
@@ -22,7 +33,7 @@ Key fields:
 {
   "schema_version": 1,
   "run_id": "job-id",
-  "input_type": "image|images|pdf|pptx",
+  "input_type": "image|images|pdf|pptx|hybrid-pptx",
   "max_concurrent_pages": 6,
   "image_backend": {},
   "pages": [],
@@ -30,6 +41,21 @@ Key fields:
   "output": "final/origin_edited.pptx"
 }
 ```
+
+For `hybrid-pptx`, `source_slide` stores the original `width_emu` and `height_emu`. Every page entry also contains a runtime-owned `replacement_target`:
+
+```json
+{
+  "slide_part": "ppt/slides/slide1.xml",
+  "picture_shape_id": 7,
+  "picture_name": "Picture 6",
+  "relationship_id": "rId3",
+  "z_index": 4,
+  "frame_emu": {"x": 0, "y": 1504977, "cx": 12192000, "cy": 3848046}
+}
+```
+
+The target identifies exactly one embedded, uncropped, unrotated, unflipped picture on the source slide. `frame_emu` is expressed in the picture's immediate shape-tree coordinate system so grouped pictures can be replaced without flattening or moving their native siblings. The runtime writes and consumes these fields; page reconstructors must not edit them.
 
 `image_backend` is written with defaults by `editppt prepare` and may be overwritten by `editppt run backend` when needed.
 
@@ -84,6 +110,7 @@ Includes:
 - required outputs
 - user constraints
 - image backend contract
+- hybrid picture replacement target, when present
 
 Must not include:
 
@@ -93,7 +120,7 @@ Must not include:
 
 If the run uses an image backend, `page_request.json` must contain the same `image_backend`.
 
-`slide` and `content_box` are computed automatically by `editppt prepare`. Inputs close to 16:9 use the standard widescreen canvas; other inputs use a custom canvas converted from the source image pixel dimensions. The agent must copy these two fields into the page `manifest.json` and must not compress, stretch, or recalculate the canvas.
+`slide` and `content_box` are computed automatically by `editppt prepare`. Inputs close to 16:9 use the standard widescreen canvas; other inputs use a custom canvas converted from the source image pixel dimensions. For a hybrid page this is the extracted picture's local reconstruction canvas; `replacement_target` separately records where finalization maps it into the source slide. The agent must copy `slide` and `content_box` into the page `manifest.json` and must not compress, stretch, or recalculate the canvas.
 
 ## `page_result.json`
 

--- a/tests/test_hybrid_pptx.py
+++ b/tests/test_hybrid_pptx.py
@@ -1,0 +1,83 @@
+import json
+import sys
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+from PIL import Image
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNTIME_DIR = ROOT / "skills/image-to-editable-ppt/cli/editppt/runtime"
+sys.path.insert(0, str(RUNTIME_DIR))
+
+from _input_normalization import normalize_inputs  # noqa: E402
+from build_pptx_from_manifest import page_entries_from_deck_manifest, write_deck, write_pptx  # noqa: E402
+from prepare_deck_run import upgrade_deck_manifest  # noqa: E402
+
+
+NS = {
+    "a": "http://schemas.openxmlformats.org/drawingml/2006/main",
+    "p": "http://schemas.openxmlformats.org/presentationml/2006/main",
+    "rel": "http://schemas.openxmlformats.org/package/2006/relationships",
+}
+
+
+def write_json(path, value):
+    path.write_text(json.dumps(value, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+class HybridPptxTests(unittest.TestCase):
+    def test_preserves_native_objects_and_replaces_only_embedded_picture(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source_image = root / "flattened.png"
+            Image.new("RGB", (800, 400), "#ddeeff").save(source_image)
+            source_manifest = {
+                "source": {"width_px": 1600, "height_px": 900},
+                "slide": {"width": 13.333, "height": 7.5},
+                "content_box": {"left": 0, "top": 0, "width": 13.333, "height": 7.5},
+                "text_boxes": [{"text": "KEEP ME", "box_px": [80, 40, 400, 70], "font_size": 22}],
+                "shapes": [],
+                "images": [{"path": str(source_image), "box_px": [200, 240, 1000, 500]}],
+            }
+            source_pptx = root / "source.pptx"
+            write_pptx(source_manifest, source_pptx, root / "source.json")
+
+            run_dir = root / "run"
+            deck_path = normalize_inputs([source_pptx], job_dir=run_dir)
+            deck = upgrade_deck_manifest(deck_path, 2)
+            self.assertEqual("hybrid-pptx", deck["input_type"])
+            self.assertEqual(1, deck["page_count"])
+            self.assertIn("replacement_target", deck["pages"][0])
+
+            page_dir = run_dir / "pages/page_001"
+            rebuilt = {
+                "source": {"width_px": 800, "height_px": 400},
+                "slide": {"width": 13.333, "height": 6.6665},
+                "content_box": {"left": 0, "top": 0, "width": 13.333, "height": 6.6665},
+                "text_boxes": [{"text": "REBUILT", "box_px": [40, 30, 300, 60], "font_size": 18}],
+                "shapes": [{"type": "rect", "box_px": [20, 20, 500, 100], "fill": "#ffffff", "stroke": "none"}],
+                "images": [],
+            }
+            write_json(page_dir / "manifest.json", rebuilt)
+            deck, entries, notes = page_entries_from_deck_manifest(deck_path)
+            output = root / "hybrid-output.pptx"
+            write_deck(deck, entries, output, notes)
+
+            with zipfile.ZipFile(output) as pptx:
+                slide = ET.fromstring(pptx.read("ppt/slides/slide1.xml"))
+                texts = [node.text or "" for node in slide.findall(".//a:t", NS)]
+                self.assertIn("KEEP ME", texts)
+                self.assertIn("REBUILT", texts)
+                self.assertEqual([], slide.findall(".//p:pic", NS))
+                rels = ET.fromstring(pptx.read("ppt/slides/_rels/slide1.xml.rels"))
+                image_rels = [rel for rel in rels.findall("rel:Relationship", NS) if rel.attrib.get("Type", "").endswith("/image")]
+                self.assertEqual([], image_rels)
+                self.assertEqual([], [name for name in pptx.namelist() if name.startswith("ppt/media/")])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hybrid_pptx.py
+++ b/tests/test_hybrid_pptx.py
@@ -29,22 +29,93 @@ def write_json(path, value):
     path.write_text(json.dumps(value, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
 
+def marker_shape(shape_id, name, x):
+    p_ns = NS["p"]
+    a_ns = NS["a"]
+    shape = ET.Element(f"{{{p_ns}}}sp")
+    non_visual = ET.SubElement(shape, f"{{{p_ns}}}nvSpPr")
+    ET.SubElement(non_visual, f"{{{p_ns}}}cNvPr", id=str(shape_id), name=name)
+    ET.SubElement(non_visual, f"{{{p_ns}}}cNvSpPr")
+    ET.SubElement(non_visual, f"{{{p_ns}}}nvPr")
+    properties = ET.SubElement(shape, f"{{{p_ns}}}spPr")
+    transform = ET.SubElement(properties, f"{{{a_ns}}}xfrm")
+    ET.SubElement(transform, f"{{{a_ns}}}off", x=str(x), y="0")
+    ET.SubElement(transform, f"{{{a_ns}}}ext", cx="100000", cy="100000")
+    geometry = ET.SubElement(properties, f"{{{a_ns}}}prstGeom", prst="rect")
+    ET.SubElement(geometry, f"{{{a_ns}}}avLst")
+    return shape
+
+
+def wrap_picture_in_group(pptx_path):
+    """Move the source picture into a real group with a non-identity transform."""
+    p_ns = NS["p"]
+    a_ns = NS["a"]
+    ET.register_namespace("a", a_ns)
+    ET.register_namespace("p", p_ns)
+    ET.register_namespace("r", "http://schemas.openxmlformats.org/officeDocument/2006/relationships")
+    with zipfile.ZipFile(pptx_path) as source:
+        parts = {name: source.read(name) for name in source.namelist()}
+
+    slide = ET.fromstring(parts["ppt/slides/slide1.xml"])
+    shape_tree = slide.find(".//p:spTree", NS)
+    picture = shape_tree.find("p:pic", NS)
+    picture_index = list(shape_tree).index(picture)
+    shape_tree.remove(picture)
+
+    group = ET.Element(f"{{{p_ns}}}grpSp")
+    non_visual = ET.SubElement(group, f"{{{p_ns}}}nvGrpSpPr")
+    ET.SubElement(non_visual, f"{{{p_ns}}}cNvPr", id="20", name="Test Group")
+    ET.SubElement(non_visual, f"{{{p_ns}}}cNvGrpSpPr")
+    ET.SubElement(non_visual, f"{{{p_ns}}}nvPr")
+    group_properties = ET.SubElement(group, f"{{{p_ns}}}grpSpPr")
+    transform = ET.SubElement(group_properties, f"{{{a_ns}}}xfrm")
+    ET.SubElement(transform, f"{{{a_ns}}}off", x="100000", y="200000")
+    ET.SubElement(transform, f"{{{a_ns}}}ext", cx="8000000", cy="4000000")
+    ET.SubElement(transform, f"{{{a_ns}}}chOff", x="0", y="0")
+    ET.SubElement(transform, f"{{{a_ns}}}chExt", cx="12191695", cy="6858000")
+    group.append(marker_shape(21, "Before Picture", 10000))
+    group.append(picture)
+    group.append(marker_shape(22, "After Picture", 12000000))
+    shape_tree.insert(picture_index, group)
+    parts["ppt/slides/slide1.xml"] = ET.tostring(slide, encoding="utf-8", xml_declaration=True)
+
+    rewritten = pptx_path.with_name("grouped-source.pptx")
+    with zipfile.ZipFile(rewritten, "w", zipfile.ZIP_DEFLATED) as output:
+        for name, data in parts.items():
+            output.writestr(name, data)
+    return rewritten
+
+
+def source_manifest(source_image):
+    return {
+        "source": {"width_px": 1600, "height_px": 900},
+        "slide": {"width": 13.333, "height": 7.5},
+        "content_box": {"left": 0, "top": 0, "width": 13.333, "height": 7.5},
+        "text_boxes": [{"text": "KEEP ME", "box_px": [80, 40, 400, 70], "font_size": 22}],
+        "shapes": [],
+        "images": [{"path": str(source_image), "box_px": [200, 240, 1000, 500]}],
+    }
+
+
+def rebuilt_manifest():
+    return {
+        "source": {"width_px": 800, "height_px": 400},
+        "slide": {"width": 13.333, "height": 6.6665},
+        "content_box": {"left": 0, "top": 0, "width": 13.333, "height": 6.6665},
+        "text_boxes": [{"text": "REBUILT", "box_px": [40, 30, 300, 60], "font_size": 18}],
+        "shapes": [{"type": "rect", "box_px": [20, 20, 500, 100], "fill": "#ffffff", "stroke": "none"}],
+        "images": [],
+    }
+
+
 class HybridPptxTests(unittest.TestCase):
     def test_preserves_native_objects_and_replaces_only_embedded_picture(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             source_image = root / "flattened.png"
             Image.new("RGB", (800, 400), "#ddeeff").save(source_image)
-            source_manifest = {
-                "source": {"width_px": 1600, "height_px": 900},
-                "slide": {"width": 13.333, "height": 7.5},
-                "content_box": {"left": 0, "top": 0, "width": 13.333, "height": 7.5},
-                "text_boxes": [{"text": "KEEP ME", "box_px": [80, 40, 400, 70], "font_size": 22}],
-                "shapes": [],
-                "images": [{"path": str(source_image), "box_px": [200, 240, 1000, 500]}],
-            }
             source_pptx = root / "source.pptx"
-            write_pptx(source_manifest, source_pptx, root / "source.json")
+            write_pptx(source_manifest(source_image), source_pptx, root / "source.json")
 
             run_dir = root / "run"
             deck_path = normalize_inputs([source_pptx], job_dir=run_dir)
@@ -54,15 +125,7 @@ class HybridPptxTests(unittest.TestCase):
             self.assertIn("replacement_target", deck["pages"][0])
 
             page_dir = run_dir / "pages/page_001"
-            rebuilt = {
-                "source": {"width_px": 800, "height_px": 400},
-                "slide": {"width": 13.333, "height": 6.6665},
-                "content_box": {"left": 0, "top": 0, "width": 13.333, "height": 6.6665},
-                "text_boxes": [{"text": "REBUILT", "box_px": [40, 30, 300, 60], "font_size": 18}],
-                "shapes": [{"type": "rect", "box_px": [20, 20, 500, 100], "fill": "#ffffff", "stroke": "none"}],
-                "images": [],
-            }
-            write_json(page_dir / "manifest.json", rebuilt)
+            write_json(page_dir / "manifest.json", rebuilt_manifest())
             deck, entries, notes = page_entries_from_deck_manifest(deck_path)
             output = root / "hybrid-output.pptx"
             write_deck(deck, entries, output, notes)
@@ -72,6 +135,66 @@ class HybridPptxTests(unittest.TestCase):
                 texts = [node.text or "" for node in slide.findall(".//a:t", NS)]
                 self.assertIn("KEEP ME", texts)
                 self.assertIn("REBUILT", texts)
+                self.assertEqual([], slide.findall(".//p:pic", NS))
+                rels = ET.fromstring(pptx.read("ppt/slides/_rels/slide1.xml.rels"))
+                image_rels = [rel for rel in rels.findall("rel:Relationship", NS) if rel.attrib.get("Type", "").endswith("/image")]
+                self.assertEqual([], image_rels)
+                self.assertEqual([], [name for name in pptx.namelist() if name.startswith("ppt/media/")])
+
+    def test_replaces_picture_inside_group_with_group_local_coordinates(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source_image = root / "flattened.png"
+            Image.new("RGB", (800, 400), "#ddeeff").save(source_image)
+            source_pptx = root / "source.pptx"
+            write_pptx(source_manifest(source_image), source_pptx, root / "source.json")
+            grouped_pptx = wrap_picture_in_group(source_pptx)
+
+            run_dir = root / "run"
+            deck_path = normalize_inputs([grouped_pptx], job_dir=run_dir)
+            deck = upgrade_deck_manifest(deck_path, 2)
+            target = deck["pages"][0]["replacement_target"]
+            self.assertEqual("hybrid-pptx", deck["input_type"])
+            self.assertEqual(3, target["z_index"])
+
+            page_dir = run_dir / "pages/page_001"
+            write_json(page_dir / "manifest.json", rebuilt_manifest())
+            deck, entries, notes = page_entries_from_deck_manifest(deck_path)
+            output = root / "grouped-output.pptx"
+            write_deck(deck, entries, output, notes)
+
+            with zipfile.ZipFile(output) as pptx:
+                slide = ET.fromstring(pptx.read("ppt/slides/slide1.xml"))
+                group = next(
+                    candidate
+                    for candidate in slide.findall(".//p:grpSp", NS)
+                    if candidate.find("p:nvGrpSpPr/p:cNvPr", NS).attrib.get("name") == "Test Group"
+                )
+                group_transform = group.find("p:grpSpPr/a:xfrm", NS)
+                self.assertEqual({"x": "100000", "y": "200000"}, group_transform.find("a:off", NS).attrib)
+                self.assertEqual({"cx": "8000000", "cy": "4000000"}, group_transform.find("a:ext", NS).attrib)
+
+                object_names = []
+                generated_rect = None
+                for shape in group.findall("p:sp", NS):
+                    properties = shape.find("p:nvSpPr/p:cNvPr", NS)
+                    name = properties.attrib.get("name")
+                    object_names.append(name)
+                    if name.startswith("Rect"):
+                        generated_rect = shape
+                self.assertEqual(4, len(object_names))
+                self.assertEqual("Before Picture", object_names[0])
+                self.assertTrue(object_names[1].startswith("Rect"))
+                self.assertTrue(object_names[2].startswith("TextBox"))
+                self.assertEqual("After Picture", object_names[3])
+
+                frame = target["frame_emu"]
+                expected_x = round(frame["x"] + 20 / 800 * frame["cx"])
+                expected_y = round(frame["y"] + 20 / 400 * frame["cy"])
+                rect_offset = generated_rect.find("p:spPr/a:xfrm/a:off", NS)
+                self.assertEqual(expected_x, int(rect_offset.attrib["x"]))
+                self.assertEqual(expected_y, int(rect_offset.attrib["y"]))
+
                 self.assertEqual([], slide.findall(".//p:pic", NS))
                 rels = ET.fromstring(pptx.read("ppt/slides/_rels/slide1.xml.rels"))
                 image_rels = [rel for rel in rels.findall("rel:Relationship", NS) if rel.attrib.get("Type", "").endswith("/image")]


### PR DESCRIPTION
## 背景

当前轻量 PPTX 路径只接受“每页恰好一张全页图片、且没有原生文字”的文件。遇到“原生 PPT 元素 + 扁平图片区域”的混合页面时，现有提示要求先转成 PDF 或页面图片，这会丢失本来已经可编辑的对象，也会扩大重建范围、增加耗时和 token 成本。

这次改动来自一个真实的 3 页中文课件案例：原文件已有 47 个原生文本框，同时每页包含一个 TIFF 扁平图片区。我们验证过更合适的策略是保留这些原生对象，只重建 TIFF 区域，再把重建结果放回原 PPTX。

## 改动内容

- `editppt prepare` 新增 `hybrid-pptx` 检测：当页面包含原生对象和一个嵌入图片时，只提取该图片作为页面 worker 的 `source.png`。
- 记录目标图片的 slide part、shape id、relationship id、层级位置及 EMU 坐标；支持图片位于 PowerPoint 分组内部。
- 页面 worker 继续在独立的局部画布中工作，无需理解或重建页面上已有的原生对象。
- `editppt run finalize` 以原 PPTX 包为基底，在目标图片的原层级位置插入 manifest 中的文字、形状和图片资产，同时保留其他 slide XML、母版、备注及包内资源。
- 清理不再被引用的原始图片 relationship 和媒体文件。
- 补充混合 PPTX 回归测试、manifest 字段文档、中英文 README 和 changelog。

## 实际效果

在上述 3 页案例中，使用昨天已经人工核对过的页面 manifest 和资产验证新 pipeline，未重新调用 OCR、图片模型或 page worker：

- 输出仍为 3 页，页序不变。
- 原有 47 个 PPT 原生文本框和相关分组继续保留。
- 3 个 TIFF 图片对象被重建内容替换。
- 最终包含 21 个可独立移动的图片资产，以及新增的原生文本、线条和形状。
- PPTX 包中没有 TIFF 残留，压缩包结构检查通过。
- 重建内容与已人工核对版本使用相同的 manifest、资产和位置映射，因此视觉内容保持一致。

性能收益来自减少重建范围：页面 worker 不再重新识别和复刻已经是 PowerPoint 对象的内容，只处理扁平图片区。在这个案例中，47 个已有文本框直接复用。当前没有做严格的全页重建 A/B 计时，因此不声明具体加速倍数。

## 验证

- `python3 -m unittest tests.test_hybrid_pptx tests.test_slide_layout tests.test_quality_contracts tests.test_script_inventory -q`：24 项测试通过。
- 新增真实 `p:grpSp` 回归测试，覆盖组内原位置插入、非恒等组坐标映射、原生兄弟对象顺序，以及图片 relationship/孤立媒体清理。
- 使用真实源文件完成 `prepare`：3 页均正确识别为 `hybrid-pptx`，并定位到分组内目标图片。
- 使用真实的 3 页重建 manifest 和 21 个资产完成自动 final assembly。
- `unzip -t` 检查最终 PPTX：通过。
- 整个复验过程复用现有产物，没有额外 OCR、图片生成或页面重建调用。

## 首版边界

- 每页必须恰好有一个嵌入图片。
- 暂不支持同页多个图片、外链图片，以及裁剪、旋转或翻转过的目标图片。
- 如果不满足边界，`prepare` 会明确报错，不会静默转成 PDF 或破坏已有原生对象。
