### PR TITLE
chore: prepare v0.3.2-beta.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,22 +4,21 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ## Unreleased
 
+## 0.3.2-beta.1
+
 ### Features
 
-- Prefer the agent built-in `image_gen.imagegen` tool for image generation and editing, with explicit fallback to Codex OAuth and then an OpenAI-compatible API only for defined failure conditions, while recording the actual producing backend.
+- Prefer the agent built-in `image_gen.imagegen` tool for image generation and editing, with explicit fallback to Codex OAuth and then an OpenAI-compatible API only for defined failure conditions, while recording the actual producing backend. (#22)
 
 ### Fixes
 
-- Scope `editppt image process-sheet` intermediate images and split reports by job id, and reject an existing alpha output before copying a new source sheet.
+- Scope `editppt image process-sheet` intermediate images and split reports by job id, and reject an existing alpha output before copying a new source sheet. (#22)
+- Translate manifest text alignment values to valid DrawingML enums, center preview text within its box, and reject unsupported alignment values during page validation. (#17)
 
 ### Documentation
 
 - Add an investment-platform before-and-after example to both READMEs. (#23)
 - Add a docsify-based documentation site under `docs/` (home, quickstart, design, installation, workflow, FAQ, prompts) served via GitHub Pages, and link it from both READMEs. (#18)
-
-### Fixes
-
-- Translate manifest text alignment values to valid DrawingML enums, center preview text within its box, and reject unsupported alignment values during page validation. (#17)
 
 ## 0.3.1
 


### PR DESCRIPTION
## Summary

- move current unreleased changes into the `0.3.2-beta.1` changelog section
- consolidate fix entries and add the missing PR references for the built-in image backend work
- prepare release notes for the beta tag workflow

## Verification

- `python3 -m pytest -q` — 82 passed, 14 subtests passed
- `git diff --check`
- validated that the workflow can extract a non-empty `0.3.2-beta.1` section with PR references

## Notes

- after merge, tag the merge commit as `v0.3.2-beta.1` and push the tag