### PR TITLE
Fix PowerPoint OOXML generation and enhance line features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Release notes are generated from this file. Keep changelog entries in English.
 - Build exported decks with the standard `python-pptx` OOXML package structure and validate Microsoft PowerPoint-required parts, replacing the hand-written minimal package that LibreOffice accepted but Windows PowerPoint could reject. (#1)
 - Preserve SVG assets as native SVG DrawingML parts without generating PNG compatibility fallbacks. (#1)
 - Store solid text backgrounds and borders on the editable text box itself instead of requiring a duplicate backing shape. (#1)
+- Build ordinary arrows as one editable PowerPoint line with native start/end arrowheads instead of a detached line-and-triangle pair.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ## Unreleased
 
+### Fixes
+
+- Build exported decks with the standard `python-pptx` OOXML package structure and validate Microsoft PowerPoint-required parts, replacing the hand-written minimal package that LibreOffice accepted but Windows PowerPoint could reject. (#1)
+- Preserve SVG assets as native SVG DrawingML parts without generating PNG compatibility fallbacks. (#1)
+- Store solid text backgrounds and borders on the editable text box itself instead of requiring a duplicate backing shape. (#1)
+
 ### Documentation
 
 - Add complete Korean README and English and Korean versions of the Docsify usage documentation, with synchronized language navigation, search, and pagination. (#26)

--- a/skills/image-to-editable-ppt/cli/editppt/runtime/build_pptx_from_manifest.py
+++ b/skills/image-to-editable-ppt/cli/editppt/runtime/build_pptx_from_manifest.py
@@ -7,9 +7,14 @@ import re
 import subprocess
 import sys
 import tempfile
-import zipfile
 from copy import deepcopy
 from pathlib import Path
+
+from pptx import Presentation
+from pptx.opc.constants import RELATIONSHIP_TYPE as RT
+from pptx.opc.package import Part
+from pptx.oxml import parse_xml
+from pptx.util import Emu
 
 
 EMU_PER_INCH = 914400
@@ -36,8 +41,6 @@ TEXT_VERTICAL_ALIGNMENTS = {
     "ctr": ("ctr", "middle"),
     "b": ("b", "bottom"),
 }
-
-
 def emu(value):
     return int(round(float(value) * EMU_PER_INCH))
 
@@ -354,6 +357,8 @@ def text_box_xml(idx, item):
     wrap = item.get("wrap", "none")
     autofit = item.get("autofit", "none")
     autofit_xml = "<a:spAutoFit/>" if autofit == "shape" else "<a:noAutofit/>"
+    fill = shape_fill(item.get("fill"))
+    line = shape_line_xml(item.get("stroke"), item.get("stroke_width", 1), item.get("dash"))
     paragraphs = item.get("paragraphs")
     runs = item.get("runs")
 
@@ -393,7 +398,7 @@ def text_box_xml(idx, item):
     return f"""
       <p:sp>
         <p:nvSpPr><p:cNvPr id="{idx}" name="TextBox {idx}"/><p:cNvSpPr txBox="1"/><p:nvPr/></p:nvSpPr>
-        <p:spPr><a:xfrm{rotation_attr}><a:off x="{left}" y="{top}"/><a:ext cx="{width}" cy="{height}"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom><a:noFill/><a:ln><a:noFill/></a:ln></p:spPr>
+        <p:spPr><a:xfrm{rotation_attr}><a:off x="{left}" y="{top}"/><a:ext cx="{width}" cy="{height}"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom>{fill}{line}</p:spPr>
         <p:txBody>
           <a:bodyPr wrap="{xml_text(wrap)}" anchor="{anchor}" lIns="0" tIns="0" rIns="0" bIns="0">{autofit_xml}</a:bodyPr><a:lstStyle/>
           {text_body}
@@ -407,10 +412,17 @@ def image_xml(idx, rel_id, item):
     width = emu(item.get("width", 1))
     height = emu(item.get("height", 1))
     name = xml_text(item.get("alt") or Path(item.get("path", "")).stem or f"Image {idx}")
+    if Path(item.get("path", "")).suffix.lower() == ".svg":
+        blip = (
+            '<a:blip><a:extLst><a:ext uri="{96DAC541-7B7A-43D3-8B79-37D633B846F1}">'
+            f'<asvg:svgBlip r:embed="{rel_id}"/></a:ext></a:extLst></a:blip>'
+        )
+    else:
+        blip = f'<a:blip r:embed="{rel_id}"/>'
     return f"""
       <p:pic>
-        <p:nvPicPr><p:cNvPr id="{idx}" name="{name}"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr>
-        <p:blipFill><a:blip r:embed="{rel_id}"/><a:stretch><a:fillRect/></a:stretch></p:blipFill>
+        <p:nvPicPr><p:cNvPr id="{idx}" name="{name}" descr="{name}"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr>
+        <p:blipFill>{blip}<a:stretch><a:fillRect/></a:stretch></p:blipFill>
         <p:spPr><a:xfrm><a:off x="{left}" y="{top}"/><a:ext cx="{width}" cy="{height}"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr>
       </p:pic>"""
 
@@ -664,25 +676,79 @@ def write_common_parts(z, slide_count, width, height, notes_count):
         z.writestr("ppt/notesMasters/_rels/notesMaster1.xml.rels", notes_master_rels_xml())
 
 
+def _shape_element(fragment):
+    namespaces = (
+        'xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" '
+        'xmlns:asvg="http://schemas.microsoft.com/office/drawing/2016/SVG/main" '
+        'xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" '
+        'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"'
+    )
+    return parse_xml(f"<root {namespaces}>{fragment}</root>")[0]
+
+
+def _image_relationship(slide, item, base):
+    path = Path(item["path"])
+    if not path.is_absolute():
+        path = base / path
+    package = slide.part.package
+    part = Part(
+        package.next_partname(f"/ppt/media/image%d{image_ext(path)}"),
+        content_type_for(path),
+        package,
+        path.read_bytes(),
+    )
+    return slide.part.relate_to(part, RT.IMAGE)
+
+
+def _add_slide(prs, manifest, manifest_path, notes_text=None):
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    background = slide_background_xml(manifest.get("slide", {}))
+    if background:
+        slide._element.cSld.insert(0, _shape_element(background))
+
+    layered = []
+    for index, item in enumerate(manifest.get("shapes", [])):
+        layered.append((float(item.get("z_index", 100)), index, "shape", item))
+    for index, item in enumerate(manifest.get("images", [])):
+        layered.append((float(item.get("z_index", 200)), index, "image", item))
+    for index, item in enumerate(manifest.get("text_boxes", [])):
+        layered.append((float(item.get("z_index", 300)), index, "text", item))
+
+    base = Path(manifest_path).resolve().parent
+    for _z_index, _order, kind, item in sorted(layered, key=lambda entry: (entry[0], entry[1])):
+        shape_id = slide.shapes._next_shape_id
+        if kind == "shape":
+            fragment = shape_xml(shape_id, item)
+        elif kind == "image":
+            fragment = image_xml(shape_id, _image_relationship(slide, item, base), item)
+        else:
+            fragment = text_box_xml(shape_id, item)
+        slide.shapes._spTree.insert_element_before(_shape_element(fragment), "p:extLst")
+
+    if notes_text:
+        notes_frame = slide.notes_slide.notes_text_frame
+        if notes_frame is not None:
+            notes_frame.text = str(notes_text)
+    return slide
+
+
+def _new_presentation(width, height):
+    prs = Presentation()
+    prs.slide_width = Emu(width)
+    prs.slide_height = Emu(height)
+    prs.core_properties.title = "Image to editable PPT"
+    return prs
+
+
 def write_pptx(manifest, out_path, manifest_path):
     width = emu(manifest.get("slide", {}).get("width", 13.333))
     height = emu(manifest.get("slide", {}).get("height", 7.5))
     out = Path(out_path)
     out.parent.mkdir(parents=True, exist_ok=True)
     normalized = normalize_manifest(manifest)
-    media_index = 1
-    with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as z:
-        z.writestr("[Content_Types].xml", content_types_xml([normalized], []))
-        write_common_parts(z, 1, width, height, 0)
-        z.writestr("ppt/slides/slide1.xml", slide_xml(normalized))
-        z.writestr("ppt/slides/_rels/slide1.xml.rels", rels_xml(normalized, media_index, None))
-        base = Path(manifest_path).resolve().parent
-        for item in normalized.get("images", []):
-            src = Path(item["path"])
-            if not src.is_absolute():
-                src = base / src
-            z.write(src, f"ppt/media/image{media_index}{image_ext(src)}")
-            media_index += 1
+    prs = _new_presentation(width, height)
+    _add_slide(prs, normalized, manifest_path)
+    prs.save(out)
 
 
 def deck_slide_size(deck, page_entries):
@@ -699,33 +765,12 @@ def write_deck(deck, page_entries, out_path, notes_entries):
     out = Path(out_path)
     out.parent.mkdir(parents=True, exist_ok=True)
     notes_by_page = {int(entry.get("page_index", 0)): entry for entry in notes_entries if entry.get("text")}
-    notes_indices = sorted(notes_by_page)
     normalized_entries = [{**entry, "manifest": normalize_manifest(entry["manifest"])} for entry in page_entries]
-    manifests = [entry["manifest"] for entry in normalized_entries]
-    media_index = 1
-    with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as z:
-        z.writestr("[Content_Types].xml", content_types_xml(manifests, notes_indices))
-        write_common_parts(z, len(page_entries), width, height, len(notes_by_page))
-        for slide_index, entry in enumerate(normalized_entries, start=1):
-            manifest = entry["manifest"]
-            notes_index = slide_index if slide_index in notes_by_page else None
-            z.writestr(f"ppt/slides/slide{slide_index}.xml", slide_xml(manifest))
-            z.writestr(f"ppt/slides/_rels/slide{slide_index}.xml.rels", rels_xml(manifest, media_index, notes_index))
-            base = Path(entry["manifest_path"]).resolve().parent
-            for item in manifest.get("images", []):
-                src = Path(item["path"])
-                if not src.is_absolute():
-                    src = base / src
-                z.write(src, f"ppt/media/image{media_index}{image_ext(src)}")
-                media_index += 1
-            if notes_index is not None:
-                note = notes_by_page[slide_index]
-                notes_xml = note.get("notes_xml")
-                if notes_xml and Path(notes_xml).exists():
-                    z.writestr(f"ppt/notesSlides/notesSlide{notes_index}.xml", Path(notes_xml).read_bytes())
-                else:
-                    z.writestr(f"ppt/notesSlides/notesSlide{notes_index}.xml", notes_slide_xml(note.get("text", "")))
-                z.writestr(f"ppt/notesSlides/_rels/notesSlide{notes_index}.xml.rels", notes_rels_xml(slide_index))
+    prs = _new_presentation(width, height)
+    for slide_index, entry in enumerate(normalized_entries, start=1):
+        note = notes_by_page.get(slide_index, {})
+        _add_slide(prs, entry["manifest"], entry["manifest_path"], note.get("text"))
+    prs.save(out)
 
 
 def page_entries_from_deck_manifest(deck_manifest_path):
@@ -862,6 +907,18 @@ def render_preview(manifest, manifest_path, out_path):
         box_height = max(1, int(item.get("height", 0.4) * scale))
         rotation = float(item.get("rotation", 0) or 0)
 
+        def draw_background(target_draw, origin_x, origin_y):
+            background = preview_color(item.get("fill"))
+            stroke = preview_color(item.get("stroke"))
+            if background not in (None, "none") or stroke not in (None, "none"):
+                stroke_width = max(1, int(round(float(item.get("stroke_width", 1)) * scale / 72)))
+                target_draw.rectangle(
+                    (origin_x, origin_y, origin_x + box_width - 1, origin_y + box_height - 1),
+                    fill=None if background in (None, "none") else background,
+                    outline=None if stroke in (None, "none") else stroke,
+                    width=stroke_width,
+                )
+
         def aligned_origin(bounds, origin_x, origin_y):
             text_width = bounds[2] - bounds[0]
             text_height = bounds[3] - bounds[1]
@@ -915,12 +972,15 @@ def render_preview(manifest, manifest_path, out_path):
 
         if rotation:
             layer = Image.new("RGBA", (box_width, box_height), (0, 0, 0, 0))
-            draw_content(ImageDraw.Draw(layer), 0, 0)
+            layer_draw = ImageDraw.Draw(layer)
+            draw_background(layer_draw, 0, 0)
+            draw_content(layer_draw, 0, 0)
             rotated = layer.rotate(-rotation, expand=True)
             paste_x = box_x + (box_width - rotated.width) // 2
             paste_y = box_y + (box_height - rotated.height) // 2
             canvas.paste(rotated, (paste_x, paste_y), rotated)
             return
+        draw_background(draw, box_x, box_y)
         draw_content(draw, box_x, box_y)
 
     layered = []

--- a/skills/image-to-editable-ppt/cli/editppt/runtime/build_pptx_from_manifest.py
+++ b/skills/image-to-editable-ppt/cli/editppt/runtime/build_pptx_from_manifest.py
@@ -320,14 +320,16 @@ def shape_fill(fill):
     return f'<a:solidFill><a:srgbClr val="{hex_color(fill)}"/></a:solidFill>'
 
 
-def shape_line_xml(stroke, width, dash=None):
+def shape_line_xml(stroke, width, dash=None, start_arrow=None, end_arrow=None):
     if not stroke or stroke == "none":
         return '<a:ln><a:noFill/></a:ln>'
     dash_xml = f'<a:prstDash val="{xml_text(dash)}"/>' if dash else ""
+    start_xml = f'<a:headEnd type="{xml_text(start_arrow)}"/>' if start_arrow else ""
+    end_xml = f'<a:tailEnd type="{xml_text(end_arrow)}"/>' if end_arrow else ""
     return (
         f'<a:ln w="{int(float(width or 1) * 12700)}">'
         f'<a:solidFill><a:srgbClr val="{hex_color(stroke)}"/></a:solidFill>'
-        f"{dash_xml}"
+        f"{dash_xml}{start_xml}{end_xml}"
         "</a:ln>"
     )
 
@@ -437,7 +439,13 @@ def shape_xml(idx, item):
     flip_h = ' flipH="1"' if item.get("flip_h") else ""
     flip_v = ' flipV="1"' if item.get("flip_v") else ""
     fill = shape_fill(item.get("fill"))
-    line = shape_line_xml(item.get("stroke", "#000000"), stroke_width, item.get("dash"))
+    line = shape_line_xml(
+        item.get("stroke", "#000000"),
+        stroke_width,
+        item.get("dash"),
+        item.get("start_arrow"),
+        item.get("end_arrow"),
+    )
     preset = item.get("preset")
     if item.get("polygon_px"):
         geometry = custom_polygon_geometry_xml(item)
@@ -849,6 +857,19 @@ def render_preview(manifest, manifest_path, out_path):
             if "points" in item:
                 points = [value * scale for value in item["points"]]
                 draw.line(points, fill=outline, width=width)
+                for key, reverse in (("start_arrow", True), ("end_arrow", False)):
+                    if item.get(key) != "triangle":
+                        continue
+                    x1, y1, x2, y2 = points
+                    if reverse:
+                        x1, y1, x2, y2 = x2, y2, x1, y1
+                    angle = math.atan2(y2 - y1, x2 - x1)
+                    size = max(6, width * 4)
+                    base = [
+                        (x2 - size * math.cos(angle + offset), y2 - size * math.sin(angle + offset))
+                        for offset in (-0.5, 0.5)
+                    ]
+                    draw.polygon([(x2, y2), *base], fill=outline)
                 return
             if item.get("dash"):
                 draw_dashed_line(draw, box, outline, width)

--- a/skills/image-to-editable-ppt/cli/editppt/runtime/runtime_env.py
+++ b/skills/image-to-editable-ppt/cli/editppt/runtime/runtime_env.py
@@ -178,7 +178,7 @@ def collect_status(check_api=False):
 
     dependencies = {
         module: current_python_has_module(module)
-        for module in ("fitz", "PIL", "openai", "yaml", "numpy", "requests")
+        for module in ("fitz", "PIL", "pptx", "openai", "yaml", "numpy", "requests")
     }
     api_key = values.get("OPENAI_API_KEY", "")
     api_ready = bool(api_key)

--- a/skills/image-to-editable-ppt/cli/editppt/runtime/validate_pptx.py
+++ b/skills/image-to-editable-ppt/cli/editppt/runtime/validate_pptx.py
@@ -16,6 +16,17 @@ NS = {
     "p": "http://schemas.openxmlformats.org/presentationml/2006/main",
     "rel": "http://schemas.openxmlformats.org/package/2006/relationships",
 }
+POWERPOINT_REQUIRED_PARTS = (
+    "[Content_Types].xml",
+    "_rels/.rels",
+    "ppt/presentation.xml",
+    "ppt/_rels/presentation.xml.rels",
+    "ppt/presProps.xml",
+    "ppt/viewProps.xml",
+    "ppt/tableStyles.xml",
+    "ppt/theme/theme1.xml",
+    "ppt/slideMasters/slideMaster1.xml",
+)
 
 ALLOWED_SOURCE_TYPES = {
     "asset-sheet-separated",
@@ -535,7 +546,7 @@ def validate_deck(args):
         with zipfile.ZipFile(args.pptx) as z:
             names = z.namelist()
             report["slides"] = len([n for n in names if re.match(r"ppt/slides/slide\d+\.xml$", n)])
-            for part in ("[Content_Types].xml", "_rels/.rels", "ppt/presentation.xml", "ppt/_rels/presentation.xml.rels"):
+            for part in POWERPOINT_REQUIRED_PARTS:
                 if part not in names:
                     report["missing_parts"].append(part)
             notes_texts = collect_notes_texts(z, names)
@@ -664,41 +675,33 @@ def main():
             if bad:
                 report["warnings"].append(f"Bad zip member: {bad}")
             names = z.namelist()
-            required_parts = [
-                "[Content_Types].xml",
-                "_rels/.rels",
-                "ppt/presentation.xml",
-                "ppt/_rels/presentation.xml.rels",
-            ]
-            for part in required_parts:
+            for part in POWERPOINT_REQUIRED_PARTS:
                 if part not in names:
                     report["missing_parts"].append(part)
             slide_names = sorted(n for n in names if re.match(r"ppt/slides/slide\d+\.xml$", n))
             report["slides"] = len(slide_names)
-            report["images"] = len([n for n in names if n.startswith("ppt/media/")])
+            picture_count = 0
+            for slide_name in slide_names:
+                slide_root = ET.fromstring(z.read(slide_name))
+                picture_count += len(slide_root.findall(".//p:pic", NS))
+            report["images"] = picture_count
             report["media_manifest_mismatch"] = report["images"] != report["manifest_image_count"]
-            for index, image in enumerate(manifest.get("images", []), start=1):
+            embedded_media_hashes = {
+                hashlib.sha256(z.read(name)).hexdigest()
+                for name in names
+                if name.startswith("ppt/media/")
+            }
+            for image in manifest.get("images", []):
                 image_path = image.get("path")
                 if not image_path:
                     continue
-                ext = Path(image_path).suffix.lower()
-                if ext == ".jpeg":
-                    ext = ".jpg"
-                media_name = f"ppt/media/image{index}{ext}"
                 source_path = Path(image_path)
                 if not source_path.is_absolute():
                     source_path = manifest_base / source_path
-                if media_name not in names:
-                    report["media_hash_mismatches"].append(
-                        {"path": image_path, "media": media_name, "reason": "missing media part"}
-                    )
-                    continue
                 if source_path.exists():
-                    manifest_hash = file_sha256(source_path)
-                    media_hash = hashlib.sha256(z.read(media_name)).hexdigest()
-                    if manifest_hash != media_hash:
+                    if file_sha256(source_path) not in embedded_media_hashes:
                         report["media_hash_mismatches"].append(
-                            {"path": image_path, "media": media_name, "reason": "hash mismatch"}
+                            {"path": image_path, "reason": "source bytes not found in embedded media"}
                         )
                 else:
                     report["missing_manifest_images"].append(str(image_path))

--- a/skills/image-to-editable-ppt/cli/pyproject.toml
+++ b/skills/image-to-editable-ppt/cli/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.10"
 dependencies = [
   "PyMuPDF>=1.24.0",
   "Pillow>=10.0.0",
+  "python-pptx>=1.0.0",
   "openai>=2.0.0",
   "PyYAML>=6.0.0",
   "numpy>=1.26.0",

--- a/skills/image-to-editable-ppt/references/manifest-schema.md
+++ b/skills/image-to-editable-ppt/references/manifest-schema.md
@@ -228,7 +228,7 @@ Text-size fitting:
 
 - `text_boxes[].font_size` is treated as the requested font size. The deterministic builder may clamp it downward during normalization when the requested size is too large for the resolved source-pixel box.
 - Keep default fitting enabled for first drafts. Set `fit_text: false` only when the page author has manually calibrated the box and font size.
-- `text_boxes[].box_px` should describe the source text bounds plus modest padding. Do not use an entire card, chart, table cell group, or unrelated container as the text box, because the fitter can only infer size from the box it receives.
+- `text_boxes[].box_px` should describe the source text bounds plus modest padding. For a text box carrying its own `fill`, use the full filled rectangle boundary. Do not use an entire multi-object card, chart, table cell group, or unrelated container as the text box, because the fitter can only infer size from the box it receives.
 - Optional tuning fields are `min_font_size`, `max_font_size`, `text_fit_safety`, and `line_height`.
 
 Text alignment:
@@ -236,6 +236,12 @@ Text alignment:
 - `text_boxes[].align` accepts `left`, `center`, or `right` (default `left`). The equivalent DrawingML tokens `l`, `ctr`, and `r` are also accepted.
 - `text_boxes[].valign` accepts `top`, `middle`, or `bottom` (default `top`); `center` is an alias for `middle`. The equivalent DrawingML tokens `t`, `ctr`, and `b` are also accepted.
 - The deterministic builder translates these manifest values to valid DrawingML enum tokens. Unsupported values are page-contract violations instead of silently falling back to an application default.
+
+Text box background and border:
+
+- Put a solid text background directly on the same `text_boxes[]` item with `fill: "#RRGGBB"`. The builder emits one editable PowerPoint text box carrying both text and fill.
+- Optional `stroke`, `stroke_width`, and `dash` fields put the border on that same text box.
+- Do not create a separate rectangle in `shapes[]` when its only purpose is to provide the rectangular background or border for one text box. That produces a redundant second layer and makes editing harder. Non-rectangular geometry or a container shared by multiple child objects remains a separate shape.
 
 `text_inventory` may be a list of strings or a list of structured objects. In structured objects, the fields used for exact text validation are `text`, `required_text`, `items`, or `texts`; fields such as `id`, `decision`, `description`, and `note` are only records and are not used for exact text matching. Example:
 

--- a/skills/image-to-editable-ppt/references/manifest-schema.md
+++ b/skills/image-to-editable-ppt/references/manifest-schema.md
@@ -220,6 +220,8 @@ Positioned build object requirements:
 - Every non-line `shapes[]` item must have `box_px`.
 - Every line shape must have `points_px`.
 
+A native arrow is one line shape with optional `start_arrow: "triangle"` and `end_arrow: "triangle"`.
+
 `text_inventory` and `visual_inventory` are only inventories; they do not substitute for positioned `text_boxes`, `images`, and `shapes`. The manifest must be sufficient to rebuild the page without reading any custom page script.
 
 Missing coordinates are page-contract violations. The runtime must reject them during `editppt run record` and deck validation because otherwise missing values fall back to default positions such as the top-left corner.

--- a/skills/image-to-editable-ppt/references/page-decision-tree.md
+++ b/skills/image-to-editable-ppt/references/page-decision-tree.md
@@ -197,7 +197,7 @@ These may use native PPT shapes or structural objects:
 
 - Straight lines, dashed lines, polylines.
 - Rectangles, rounded rectangles, circles, ellipses.
-- Ordinary arrows and connectors.
+- Ordinary arrows and connectors. Use one line with `start_arrow`/`end_arrow`; never detached triangles, which will not follow line edits.
 - Solid-color cards, panels, dividers, borders.
 - Tables, table lines, axes, gridlines.
 - Simple bar charts, progress bars, status color blocks.

--- a/skills/image-to-editable-ppt/references/page-decision-tree.md
+++ b/skills/image-to-editable-ppt/references/page-decision-tree.md
@@ -148,6 +148,8 @@ Step 3 rebuilds everything carried by native PowerPoint structure, plus formula 
 
 All readable text defaults to native PPT text boxes. Never use generated images to carry editable text, and never use hidden text, transparent text, 1 pt text, or off-canvas text to satisfy the text inventory. (Formulas are not ordinary text — see 3.2.)
 
+When a label, tag, button, callout, or other text object has a rectangular solid background, set `fill` on its `text_boxes[]` item so PowerPoint receives one filled text box. Do not stack a separate rectangle behind it solely for the background; use a separate shape only for non-rectangular geometry, or when the container is structurally independent of the text or contains multiple child objects.
+
 Exceptions — text that is part of brand or background identity rather than editable content:
 
 - Logo wordmarks, brand symbols, and trademark text.
@@ -174,7 +176,7 @@ Record completed calibration with `quality_checks.font_size_calibrated=true`.
 
 ### 3.2 Formula Handling
 
-Transcribe each formula from the source into LaTeX, then render it with `editppt formula render-latex` into an image asset written inside the page directory (prefer SVG; use PNG when SVG preview/PowerPoint compatibility is unstable):
+Transcribe each formula from the source into LaTeX, then render it with `editppt formula render-latex` into an SVG image asset written inside the page directory. Keep the SVG native in PowerPoint; do not create a PNG compatibility fallback:
 
 ```bash
 editppt formula render-latex <page_dir> \

--- a/tests/test_multi_agent_backend.py
+++ b/tests/test_multi_agent_backend.py
@@ -685,7 +685,7 @@ class MultiAgentBackendTest(unittest.TestCase):
             )
             self.assertEqual(0, result.returncode, result.stderr)
             payload = json.loads(result.stdout)
-            self.assertEqual({"fitz", "PIL", "openai", "yaml", "numpy", "requests"}, set(payload["dependencies"]))
+            self.assertEqual({"fitz", "PIL", "pptx", "openai", "yaml", "numpy", "requests"}, set(payload["dependencies"]))
             self.assertEqual("cli-fallback-only", payload["image_backend"]["scope"])
             self.assertFalse(payload["agent_builtin_imagegen"]["checked"])
             self.assertIsNone(payload["agent_builtin_imagegen"]["ready"])

--- a/tests/test_quality_contracts.py
+++ b/tests/test_quality_contracts.py
@@ -131,6 +131,12 @@ class QualityContractTest(unittest.TestCase):
         self.assertIn('name="adj"', xml)
         self.assertIn('fmla="val 5000"', xml)
 
+    def test_line_supports_native_start_and_end_arrows(self):
+        xml = shape_xml(2, {"type": "line", "start_arrow": "triangle", "end_arrow": "triangle"})
+
+        self.assertIn('<a:headEnd type="triangle"/>', xml)
+        self.assertIn('<a:tailEnd type="triangle"/>', xml)
+
     def test_structured_text_inventory_flattens_to_required_strings(self):
         required = required_texts_from_manifest(
             {

--- a/tests/test_slide_layout.py
+++ b/tests/test_slide_layout.py
@@ -1,9 +1,11 @@
 import sys
 import tempfile
 import unittest
+import zipfile
 from pathlib import Path
 
 from PIL import Image
+from pptx import Presentation
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -18,6 +20,8 @@ from build_pptx_from_manifest import (  # noqa: E402
     render_preview,
     slide_size_type,
     text_box_xml,
+    write_deck,
+    write_pptx,
 )
 from prepare_deck_run import fit_content_box, slide_for_source  # noqa: E402
 
@@ -51,6 +55,118 @@ def preview_ink_center(manifest):
 
 
 class SlideLayoutTest(unittest.TestCase):
+    def test_text_background_is_a_single_filled_text_box(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = {
+                "slide": {"width": 13.333, "height": 7.5},
+                "text_boxes": [
+                    {
+                        "text": "One editable layer",
+                        "box_px": [120, 90, 480, 120],
+                        "fill": "#DCEEFF",
+                        "color": "#123456",
+                        "font_size": 24,
+                    }
+                ],
+                "source": {"width_px": 1600, "height_px": 900},
+                "content_box": {"left": 0, "top": 0, "width": 13.333, "height": 7.5},
+            }
+            output = root / "filled-text-box.pptx"
+
+            write_pptx(manifest, output, root / "manifest.json")
+
+            slide = Presentation(output).slides[0]
+            self.assertEqual(1, len(slide.shapes))
+            text_box = slide.shapes[0]
+            self.assertEqual("One editable layer", text_box.text)
+            self.assertEqual("DCEEFF", str(text_box.fill.fore_color.rgb))
+
+    def test_export_uses_standard_powerpoint_ooxml_package(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            Image.new("RGB", (320, 180), "#2f6f9f").save(root / "asset.png")
+            manifest = {
+                "source": {"width_px": 1600, "height_px": 900},
+                "slide": {"width": 13.333, "height": 7.5, "background": "#ffffff"},
+                "content_box": {"left": 0, "top": 0, "width": 13.333, "height": 7.5},
+                "images": [{"path": "asset.png", "box_px": [100, 100, 400, 220]}],
+                "shapes": [
+                    {"type": "roundRect", "box_px": [600, 100, 400, 220], "source_corner_radius_px": 18, "fill": "#dbeafe"},
+                    {"type": "ellipse", "box_px": [1050, 100, 160, 160], "fill": "#dcfce7", "stroke": "none"},
+                    {"type": "line", "points_px": [600, 350, 1000, 350], "stroke": "#334155", "dash": "dash"},
+                    {"type": "polygon", "polygon_px": [[1100, 350], [1250, 450], [1050, 450]], "fill": "#fef3c7"},
+                ],
+                "text_boxes": [
+                    {
+                        "runs": [
+                            {"text": "Microsoft ", "bold": True},
+                            {"text": "PowerPoint", "color": "#1d4ed8"},
+                        ],
+                        "box_px": [100, 500, 900, 100],
+                        "font_size": 28,
+                    }
+                ],
+            }
+            manifest_path = root / "manifest.json"
+            manifest_path.write_text("{}", encoding="utf-8")
+            output = root / "standard.pptx"
+
+            write_pptx(manifest, output, manifest_path)
+
+            self.assertEqual(1, len(Presentation(output).slides))
+            with zipfile.ZipFile(output) as archive:
+                names = set(archive.namelist())
+                self.assertIn("ppt/presProps.xml", names)
+                self.assertIn("ppt/viewProps.xml", names)
+                self.assertIn("ppt/tableStyles.xml", names)
+                self.assertIn("Microsoft", archive.read("docProps/app.xml").decode("utf-8"))
+
+    def test_svg_assets_are_embedded_without_raster_fallback(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "formula.svg").write_text(
+                '<svg xmlns="http://www.w3.org/2000/svg" width="200" height="80"><text x="5" y="50">E=mc²</text></svg>',
+                encoding="utf-8",
+            )
+            manifest = {
+                "source": {"width_px": 1600, "height_px": 900},
+                "slide": {"width": 13.333, "height": 7.5},
+                "content_box": {"left": 0, "top": 0, "width": 13.333, "height": 7.5},
+                "images": [{"path": "formula.svg", "box_px": [100, 100, 600, 240]}],
+            }
+            output = root / "svg-native.pptx"
+
+            write_pptx(manifest, output, root / "manifest.json")
+
+            with zipfile.ZipFile(output) as archive:
+                media = [name for name in archive.namelist() if name.startswith("ppt/media/")]
+                self.assertEqual(1, len(media))
+                self.assertTrue(media[0].endswith(".svg"))
+                self.assertEqual((root / "formula.svg").read_bytes(), archive.read(media[0]))
+                slide_xml = archive.read("ppt/slides/slide1.xml").decode("utf-8")
+                self.assertIn("asvg:svgBlip", slide_xml)
+                self.assertNotIn(".png", "\n".join(archive.namelist()))
+
+    def test_standard_powerpoint_export_preserves_speaker_notes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = {
+                "slide": {"width": 13.333, "height": 7.5},
+                "text_boxes": [{"text": "Slide", "left": 1, "top": 1, "width": 2, "height": 1}],
+            }
+            output = root / "notes.pptx"
+
+            write_deck(
+                {"slide": {"width": 13.333, "height": 7.5}},
+                [{"manifest": manifest, "manifest_path": root / "manifest.json"}],
+                output,
+                [{"page_index": 1, "text": "Original speaker note"}],
+            )
+
+            deck = Presentation(output)
+            self.assertEqual("Original speaker note", deck.slides[0].notes_slide.notes_text_frame.text)
+
     def test_non_wide_source_uses_source_pixel_size(self):
         slide = slide_for_source(1536, 1024)
 


### PR DESCRIPTION
This pull request makes significant improvements to the way PowerPoint decks are generated and validated, focusing on compatibility with Microsoft PowerPoint, better handling of SVG assets, improved shape and text rendering, and a transition to using the standard `python-pptx` library for building `.pptx` files. It also updates the validation logic and documentation to reflect these changes.

**PowerPoint export and compatibility improvements:**

- Switched from a hand-written minimal OOXML package to building PowerPoint decks using the standard `python-pptx` library, ensuring all Microsoft PowerPoint-required parts are present and validated, improving compatibility especially on Windows. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R13) [[2]](diffhunk://#diff-8c3217db5fc18fec1910db95085ea5f7dc0ae584dc1e5bfc42e8b83bf85af420L10-R18) [[3]](diffhunk://#diff-8c3217db5fc18fec1910db95085ea5f7dc0ae584dc1e5bfc42e8b83bf85af420R687-R759) [[4]](diffhunk://#diff-8c3217db5fc18fec1910db95085ea5f7dc0ae584dc1e5bfc42e8b83bf85af420L702-R781) [[5]](diffhunk://#diff-60c3aa7313f4fba90655f404b2e6288dfb7c2d1488ed5f9c51e7a98685f35fd0R9)
- Updated the validator to check for all PowerPoint-required parts and improved image/media validation to be content-based, not just by file name. [[1]](diffhunk://#diff-7cda47cc74661d202fa2e801a9ddd0d248db15e366af49fdcbb83a13513719d4R19-R29) [[2]](diffhunk://#diff-7cda47cc74661d202fa2e801a9ddd0d248db15e366af49fdcbb83a13513719d4L538-R549) [[3]](diffhunk://#diff-7cda47cc74661d202fa2e801a9ddd0d248db15e366af49fdcbb83a13513719d4L667-R704)

**SVG and image handling:**

- SVG assets are now preserved as native SVG DrawingML parts in the `.pptx` file, without generating PNG fallbacks, improving fidelity and editability in PowerPoint. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R13) [[2]](diffhunk://#diff-8c3217db5fc18fec1910db95085ea5f7dc0ae584dc1e5bfc42e8b83bf85af420R417-R427)

**Shapes, arrows, and text rendering:**

- Ordinary arrows are now created as single editable PowerPoint lines with native start/end arrowheads, instead of a line and separate triangle shape, making them fully editable in PowerPoint. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R13) [[2]](diffhunk://#diff-8c3217db5fc18fec1910db95085ea5f7dc0ae584dc1e5bfc42e8b83bf85af420L428-R448) [[3]](diffhunk://#diff-353b23fb99a37148e4f800b0583e5e678434a89ba35afc5fd3d51cabbff74116R223-R224)
- Solid text backgrounds and borders are now stored directly on the text box shape, removing the need for a duplicate backing shape. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R13) [[2]](diffhunk://#diff-8c3217db5fc18fec1910db95085ea5f7dc0ae584dc1e5bfc42e8b83bf85af420R362-R363) [[3]](diffhunk://#diff-8c3217db5fc18fec1910db95085ea5f7dc0ae584dc1e5bfc42e8b83bf85af420R931-R942) [[4]](diffhunk://#diff-8c3217db5fc18fec1910db95085ea5f7dc0ae584dc1e5bfc42e8b83bf85af420L918-R1004)

**Documentation and dependency updates:**

- Updated documentation to clarify the manifest schema for native arrows and improved changelog entries to reflect these technical changes. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R13) [[2]](diffhunk://#diff-353b23fb99a37148e4f800b0583e5e678434a89ba35afc5fd3d51cabbff74116R223-R224)
- Added `python-pptx` as a required dependency and included it in runtime environment checks. [[1]](diffhunk://#diff-60c3aa7313f4fba90655f404b2e6288dfb7c2d1488ed5f9c51e7a98685f35fd0R9) [[2]](diffhunk://#diff-f676d893923348b74328f358ce52c3bea134d17835d5af09e03c278fc27eb486L181-R181)
