### PR TITLE
feat: add native Codex plugin metadata

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "image-to-editable-ppt",
+  "interface": {
+    "displayName": "Image to Editable PowerPoint"
+  },
+  "plugins": [
+    {
+      "name": "image-to-editable-ppt",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,38 @@
+{
+  "name": "image-to-editable-ppt",
+  "version": "0.3.2",
+  "description": "Rebuild images, PDFs, and image-based presentations as editable PowerPoint decks with faithful layout and text reconstruction.",
+  "author": {
+    "name": "ningzimu",
+    "url": "https://github.com/ningzimu"
+  },
+  "homepage": "https://ningzimu.github.io/image-to-editable-ppt-skill/",
+  "repository": "https://github.com/ningzimu/image-to-editable-ppt-skill",
+  "license": "MIT",
+  "keywords": [
+    "powerpoint",
+    "presentation",
+    "image-to-ppt",
+    "editable-slides",
+    "ocr"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Image to Editable PowerPoint",
+    "shortDescription": "Rebuild visuals as editable PowerPoint",
+    "longDescription": "Convert images, PDFs, and image-based presentations into editable PowerPoint decks using page-level reconstruction, OCR-assisted text placement, and structural validation.",
+    "developerName": "ningzimu",
+    "category": "Productivity",
+    "capabilities": [
+      "Editable presentation reconstruction",
+      "OCR-assisted text placement",
+      "PowerPoint validation"
+    ],
+    "websiteURL": "https://ningzimu.github.io/image-to-editable-ppt-skill/",
+    "defaultPrompt": [
+      "Convert this image into an editable PowerPoint slide.",
+      "Rebuild this PDF as an editable PowerPoint deck.",
+      "Convert this image-based presentation into editable slides."
+    ]
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ### Documentation
 
-- Add native Codex plugin metadata and a repository marketplace entry.
+- Add native Codex plugin metadata and a repository marketplace entry. (#34)
 - Add complete Korean README and English and Korean versions of the Docsify usage documentation, with synchronized language navigation, search, and pagination. (#26)
 - Align all usage guides with the built-in-first image backend policy and block delivery when compliant image assets cannot be produced. (#26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Release notes are generated from this file. Keep changelog entries in English.
 
 ### Documentation
 
+- Add native Codex plugin metadata and a repository marketplace entry.
 - Add complete Korean README and English and Korean versions of the Docsify usage documentation, with synchronized language navigation, search, and pagination. (#26)
 - Align all usage guides with the built-in-first image backend policy and block delivery when compliant image assets cannot be produced. (#26)
 


### PR DESCRIPTION
## Summary

- add a native `.codex-plugin/plugin.json` with upstream ownership and reader-facing plugin metadata
- add a self-contained `.agents/plugins/marketplace.json` so the repository can be added directly as a Codex marketplace
- document the new packaging metadata in the unreleased changelog
- leave the installable skill implementation unchanged

## Validation

- `plugin-creator/scripts/validate_plugin.py` passes
- all marketplace and plugin manifests parse as JSON
- tested the complete local flow with `codex plugin marketplace add`, `codex plugin add`, `codex plugin remove`, and marketplace cleanup

This gives Codex users a first-party plugin page and reinstallable repository-level package rather than a locally maintained wrapper.
